### PR TITLE
Fix various typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Newspipe Changelog
 
 - major improvements to the categories page;
 - improved displaying of numbers with localization;
-- various peformance improvements.
+- various performance improvements.
 
 
 ### Fixes
@@ -748,7 +748,7 @@ This release fixes a major bug introduced with the version 0.9.7 of SQLAlchemy
 ## 1.9 (2010-09-02)
 
     The feedgetter module was improved. More details about articles are stored
-    in the database when possile. An attempt is made to get the whole article
+    in the database when possible. An attempt is made to get the whole article
     (a_feed['entries'][i].content[j].value), and in the event of failure,
     the description/summary is used (a_feed['entries'][i].description).
 

--- a/newspipe/crawler/default_crawler.py
+++ b/newspipe/crawler/default_crawler.py
@@ -153,7 +153,7 @@ async def insert_articles(queue, nḅ_producers=1):
 
 async def retrieve_feed(queue, users, feed_id=None):
     """
-    Launch the processus.
+    Launch the process.
     """
     for user in users:
         logger.info(f"Starting to retrieve feeds for {user.nickname}")

--- a/newspipe/lib/misc_utils.py
+++ b/newspipe/lib/misc_utils.py
@@ -97,7 +97,7 @@ def opened_w_error(filename, mode="r"):
 
 def fetch(id, feed_id=None):
     """
-    Fetch the feeds in a new processus.
+    Fetch the feeds in a new process.
     The default crawler ("asyncio") is launched with the manager.
     """
     env = os.environ.copy()

--- a/newspipe/lib/utils.py
+++ b/newspipe/lib/utils.py
@@ -80,7 +80,7 @@ def to_hash(text):
 
 def clear_string(data):
     """
-    Clear a string by removing HTML tags, HTML special caracters
+    Clear a string by removing HTML tags, HTML special characters
     and consecutive white spaces (more that one).
     """
     p = re.compile("<[^>]+>")  # HTML tags

--- a/newspipe/templates/home.html
+++ b/newspipe/templates/home.html
@@ -33,7 +33,7 @@
                     {% for feed in categories[catid].feeds if feed.id in unread.keys() %}
                         <li class="nav-item feed-menu {% if in_error.get(feed.id, 0) > 0 %}d-none{% endif %}" data-bs-feed="{{ feed.id }}"><a class="nav-link" href="{{ gen_url(feed=feed.id, category=0) }}">
                                 {% if in_error.get(feed.id, 0) > 0 %}
-                                    <span style="background-color: {{ 'red' if in_error[feed.id] > 2 else 'orange' }} ;" class="badge bg-danger pull-right" title="Some errors occured while trying to retrieve that feed.">{{ in_error[fid] }}</span>
+                                    <span style="background-color: {{ 'red' if in_error[feed.id] > 2 else 'orange' }} ;" class="badge bg-danger pull-right" title="Some errors occurred while trying to retrieve that feed.">{{ in_error[fid] }}</span>
                                 {% endif %}
                                 <span id="unread-{{ feed.id }}" class="badge pull-right">{{ unread[feed.id] }}</span>
                                 <img src="{{ url_for('icon.icon', url=feeds[feed.id].icon_url) }}" width="16px">
@@ -62,7 +62,7 @@
         {% for fid, nbunread in unread|dictsort(by='value')|reverse if not feeds[fid].category_id  %}
             <li class="nav-item feed-menu {% if in_error.get(fid, 0) > 0 %}d-none{% endif %}" data-bs-feed="{{ fid }}"><a class="nav-link" href="{{ gen_url(feed=fid, category=0) }}">
                     {% if in_error.get(fid, 0) > 0 %}
-                        <span style="background-color: {{ "red" if in_error[fid] > 2 else "orange" }} ;" class="badge bg-warning text-dark pull-right" title="Some errors occured while trying to retrieve that feed.">{{ in_error[fid] }}</span>
+                        <span style="background-color: {{ "red" if in_error[fid] > 2 else "orange" }} ;" class="badge bg-warning text-dark pull-right" title="Some errors occurred while trying to retrieve that feed.">{{ in_error[fid] }}</span>
                     {% endif %}
                     <span id="unread-{{ fid }}" class="badge pull-right">{{ nbunread }}</span>
                     <img src="{{ url_for('icon.icon', url=feeds[fid].icon_url) }}" width="16px">
@@ -90,7 +90,7 @@
         {% for fid, feed in feeds.items() if not fid in unread %}
             <li class="nav-item feed-menu {% if in_error.get(fid, 0) > 0 %}d-none{% endif %}" data-bs-feed="{{ fid }}"><a class="nav-link" href="{{ gen_url(feed=fid, category=0) }}">
                 {% if in_error.get(fid, 0) > 0 %}
-                    <span style="background-color: {{ "red" if in_error[fid] > 2 else "orange" }} ;" class="badge bg-warning text-dark pull-right" title="Some errors occured while trying to retrieve that feed.">{{ in_error[fid] }}</span>
+                    <span style="background-color: {{ "red" if in_error[fid] > 2 else "orange" }} ;" class="badge bg-warning text-dark pull-right" title="Some errors occurred while trying to retrieve that feed.">{{ in_error[fid] }}</span>
                 {% endif %}
                 {% if feed_id == fid %}<b>{% endif %}
                     <img src="{{ url_for('icon.icon', url=feeds[fid].icon_url) }}" width="16px">

--- a/newspipe/web/decorators.py
+++ b/newspipe/web/decorators.py
@@ -7,7 +7,7 @@ from flask_login import login_required
 
 def async_maker(f):
     """
-    This decorator enables to launch a task (for examle sending an email or
+    This decorator enables to launch a task (for example sending an email or
     indexing the database) in background.
     This prevent the server to freeze.
     """


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.map,*.po,./node_modules" -L cace,maka,readed`

Note: some other source typos were found but not submitted:

```
./newspipe/bootstrap.py:40: formater ==> formatter
./newspipe/bootstrap.py:41: formater ==> formatter
./newspipe/commands.py:24: datas ==> data
./newspipe/web/views/admin.py:152: desactivated ==> deactivated
./newspipe/models/__init__.py:75: datas ==> data
```