### PR TITLE
Fix article rendering & sanitization, harmonize the refreshed UI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,4 @@ repos:
     rev: v2.10.0
     hooks:
       -   id: pip-audit
+          additional_dependencies: ["pip>=26.1.2"]

--- a/newspipe/static/css/theme.css
+++ b/newspipe/static/css/theme.css
@@ -205,6 +205,33 @@ a:hover {
   --bs-card-border-radius: var(--bs-border-radius);
 }
 
+/* List groups — lift onto the same soft surface card as the article list, so
+   bookmarks / inactives / popular / feed / history rows read as content, not
+   bare text on the page background. */
+.list-group {
+  --bs-list-group-bg: var(--np-surface);
+  --bs-list-group-color: var(--np-ink);
+  --bs-list-group-border-color: var(--np-border);
+  --bs-list-group-border-radius: var(--bs-border-radius);
+  --bs-list-group-action-hover-bg: var(--np-accent-soft);
+  --bs-list-group-action-hover-color: var(--np-ink);
+}
+/* Standalone lists (not flush-mounted inside a card) read as their own card. */
+.list-group:not(.list-group-flush) {
+  border-radius: var(--bs-border-radius);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+}
+.list-group-item {
+  padding: 0.75rem 1rem;
+}
+.list-group-item + .list-group-item {
+  border-top-width: 1px;
+}
+.list-group-item:hover {
+  background: var(--np-accent-soft);
+}
+
 .dropdown-menu {
   --bs-dropdown-bg: var(--np-surface);
   --bs-dropdown-border-color: var(--np-border);

--- a/newspipe/templates/admin/create_user.html
+++ b/newspipe/templates/admin/create_user.html
@@ -1,21 +1,39 @@
 {% extends "layout.html" %}
 {% block content %}
-<div class="container">
-  <h2>{{ message | safe }}</h2>
-  <form action="" method="post" name="saveprofileform" id="profileform">
-      {{ form.hidden_tag() }}
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-6 col-lg-5">
+      <div class="card shadow-sm rounded-3">
+        <div class="card-body p-4">
+          <h3 class="text-center mb-4">{{ message | safe }}</h3>
+          <form action="" method="post" name="saveprofileform" id="profileform" novalidate>
+            {{ form.hidden_tag() }}
 
-      {{ form.nickname.label }}
-      {{ form.nickname(class_="form-control") }} {% for error in form.nickname.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="mb-3">
+              {{ form.nickname.label(class_="form-label") }}
+              {{ form.nickname(class_="form-control") }}
+              {% for error in form.nickname.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-      {{ form.password.label }}
-      {% if pw_disabled %}{{ form.password(class_="form-control",disabled=True) }}{% else %}{{ form.password(class_="form-control") }}{% endif %} {% for error in form.password.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="mb-3">
+              {{ form.password.label(class_="form-label") }}
+              {% if pw_disabled %}{{ form.password(class_="form-control", disabled=True) }}{% else %}{{ form.password(class_="form-control") }}{% endif %}
+              {% for error in form.password.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-      {{ form.automatic_crawling.label }}
-      {{ form.automatic_crawling(class_="form-check-input") }} {% for error in form.automatic_crawling.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="form-check mb-3">
+              {{ form.automatic_crawling(class_="form-check-input") }}
+              {{ form.automatic_crawling.label(class_="form-check-label") }}
+              {% for error in form.automatic_crawling.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-      <br />
-      {{ form.submit(class_="btn btn-primary") }}
-  </form>
+            <div class="d-grid mb-3">
+              {{ form.submit(class_="btn btn-primary btn-lg") }}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/newspipe/templates/categories.html
+++ b/newspipe/templates/categories.html
@@ -2,29 +2,17 @@
 {% block head %}
 {{ super() }}
 <script src="{{ url_for('static', filename='npm_components/chart.js/dist/chart.umd.js') }}"></script>
-<style>
-  .chart-container {
-    display: block;
-    float: none;
-    width: 40%;
-    height: auto;
-    margin-top: 0px;
-    margin-right:0px;
-    margin-left:0px;
-  }
-</style>
 {% endblock %}
 {% block content %}
-<div class="container">
-    <h1>{{ _("You have %(categories)d categories &middot; %(start_link)sAdd%(end_link)s a category", categories=categories|count, start_link=("<a href='%s'>" % url_for("category.form"))|safe, end_link="</a>"|safe) }}</h1>
-    <br />
+<div class="container my-4">
+    <h1 class="h3 mb-4">{{ _("You have %(categories)d categories &middot; %(start_link)sAdd%(end_link)s a category", categories=categories|count, start_link=("<a href='%s'>" % url_for("category.form"))|safe, end_link="</a>"|safe) }}</h1>
     {% if categories|count == 0 %}
-        <h1>{{_("No category")}}</h1>
+        <p class="text-muted">{{_("No category")}}</p>
     {% else %}
-    <div class="row justify-content-between">
-      <div class="col-6">
+    <div class="row g-4 justify-content-between">
+      <div class="col-lg-7">
         <div class="table-responsive">
-            <table class="table table-striped">
+            <table class="table table-striped table-hover align-middle">
                 <thead>
                     <tr>
                         <th>#</th>
@@ -55,7 +43,7 @@
             </table>
         </div>
       </div>
-      <div class="col-3 chart-container">
+      <div class="col-lg-5">
         <div id="spinner" class="d-flex justify-content-center">
             <div id="spinner-border" role="status"><span class="sr-only">{{ _('Loading...') }}</span></div>
         </div>

--- a/newspipe/templates/edit_bookmark.html
+++ b/newspipe/templates/edit_bookmark.html
@@ -1,64 +1,74 @@
 {% extends "layout.html" %}
 {% block content %}
-<div class="container">
-  <div class="row d-flex justify-content-center">
-      <div class="col-md-6">
-          <h3>{{ action }}</h3>
-          <form action="" method="post" name="save" class="form-horizontal">
-              {{ form.hidden_tag() }}
-              <label for="{{ form.href.id }}" class="control-label">{{ form.href.label }}</label>
-              {{ form.href(class_="form-control", size="100%") }}
-              {% for error in form.href.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-sm rounded-3">
+        <div class="card-body p-4">
+          <h3 class="text-center mb-4">{{ action }}</h3>
+          <form action="" method="post" name="save" novalidate>
+            {{ form.hidden_tag() }}
 
-              <label for="{{ form.title.id }}" class="control-label">{{ form.title.label }}</label>
-              {{ form.title(class_="form-control", size="100%") }}
-              {% for error in form.title.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="mb-3">
+              {{ form.href.label(class_="form-label") }}
+              {{ form.href(class_="form-control") }}
+              {% for error in form.href.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-              <label for="{{ form.description.id }}" class="control-label">{{ form.description.label }}</label>
-              {{ form.description(class_="form-control", size="100%") }}
-              {% for error in form.description.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="mb-3">
+              {{ form.title.label(class_="form-label") }}
+              {{ form.title(class_="form-control") }}
+              {% for error in form.title.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-              <label for="{{ form.tags.id }}" class="control-label">{{ form.tags.label }}</label>
-              {{ form.tags(class_="form-control", size="100%") }}
-              {% for error in form.tags.errors %} <span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="mb-3">
+              {{ form.description.label(class_="form-label") }}
+              {{ form.description(class_="form-control") }}
+              {% for error in form.description.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-              <label for="{{ form.shared.id }}" class="control-label">{{ form.shared.label }}</label>
-              <div class="checkbox">
-                {{ form.shared(class_="checkbox",  style="margin-left: 0px;") }}
-              </div>
+            <div class="mb-3">
+              {{ form.tags.label(class_="form-label") }}
+              {{ form.tags(class_="form-control") }}
+              {% for error in form.tags.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
 
-              <div class="form-group">
-                  <label for="{{ form.to_read.id }}" class="control-label">{{ form.to_read.label }}</label>
-                  <div class="checkbox">
-                    {{ form.to_read(class_="checkbox",  style="margin-left: 0px;") }}
-                  </div>
-              </div>
+            <div class="form-check mb-3">
+              {{ form.shared(class_="form-check-input") }}
+              {{ form.shared.label(class_="form-check-label") }}
+            </div>
 
-              {{ form.submit(class_="btn btn-primary form-control") }}
+            <div class="form-check mb-3">
+              {{ form.to_read(class_="form-check-input") }}
+              {{ form.to_read.label(class_="form-check-label") }}
+            </div>
+
+            <div class="d-grid mb-3">
+              {{ form.submit(class_="btn btn-primary btn-lg") }}
+            </div>
           </form>
+        </div>
       </div>
-  </div>
 
-    {% if action == _('Add a new bookmark') %}
-        <div class="row d-flex justify-content-center pt-4">
-          <div class="col-md-6 float-end">
-            <hr />
+      {% if action == _('Add a new bookmark') %}
+        <div class="card shadow-sm rounded-3 mt-4">
+          <div class="card-body p-4">
             <p>{{ _('You can add a bookmark with a bookmarklet. Drag the following button to your browser bookmarks.') }}</p>
             {{ _('<a class="btn btn-primary" href="%(bookmarklet)s" rel="bookmark">Bookmark this page using Newspipe</a>', bookmarklet='javascript:window.location="%s?href="+encodeURIComponent(document.location)+"&title="+document.title' % url_for('bookmark.bookmarklet', _external=True)) }}
-          </div>
-        </div>
-        <div class="row d-flex justify-content-center pt-4">
-          <div class="col-md-6">
-            <hr />
+
+            <hr class="my-4">
+
             <form action="{{ url_for('bookmark.import_pinboard') }}" method="post" id="formImportPinboard" enctype="multipart/form-data">
-                <p>{{ _('Import bookmarks from Pinboard') }} (*.json)</p>
-                <span>
-                  <input type="file" name="jsonfile" />
-                  <button class="btn btn-primary" type="submit">OK</button>
-                </span>
+              <label class="form-label">{{ _('Import bookmarks from Pinboard') }} (*.json)</label>
+              <div class="input-group">
+                <input type="file" name="jsonfile" class="form-control" />
+                <button class="btn btn-primary" type="submit">OK</button>
+              </div>
             </form>
           </div>
         </div>
-    {% endif %}
-</div><!-- /.container -->
+      {% endif %}
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/newspipe/templates/edit_category.html
+++ b/newspipe/templates/edit_category.html
@@ -13,26 +13,40 @@
 }
 </style>
 <script src="{{ url_for('static', filename='js/multiselect-dropdown.js') }}" ></script>
-</style>
 {% endblock %}
 {% block content %}
-<div class="container">
-  <div class="row d-flex justify-content-center">
-    <div class="col-md-6">
-        <h3>{{ action }}</h3>
-        <form action="" method="post" name="save" class="form-horizontal">
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-sm rounded-3">
+        <div class="card-body p-4">
+          <h3 class="text-center mb-4">{{ action }}</h3>
+          <form action="" method="post" name="save" novalidate>
             {{ form.hidden_tag() }}
-            <label for="{{ form.name.id }}" class="control-label">{{ form.name.label }}</label>
-            {{ form.name(class_="form-control", size="100%") }}
-            {% for error in form.name.errors %}<span style="color: red;">{{ error }}<br /></span>{% endfor %}
 
-            <label for="{{ form.name.id }}" class=control-label">{{ form.feeds.label }}</label>
-            {{ form.feeds(class_="form-control", size="100%") }}
-            {% for error in form.feeds.errors %}<span style="color: red;">{{ error }}<br /></span>{% endfor %}
+            <div class="mb-3">
+              {{ form.name.label(class_="form-label") }}
+              {{ form.name(class_="form-control") }}
+              {% for error in form.name.errors %}
+                <div class="invalid-feedback d-block">{{ error }}</div>
+              {% endfor %}
+            </div>
 
-            {{ form.submit(class_="btn btn-primary form-control mt-2") }}
-        </form>
+            <div class="mb-3">
+              {{ form.feeds.label(class_="form-label") }}
+              {{ form.feeds(class_="form-control") }}
+              {% for error in form.feeds.errors %}
+                <div class="invalid-feedback d-block">{{ error }}</div>
+              {% endfor %}
+            </div>
+
+            <div class="d-grid mb-3">
+              {{ form.submit(class_="btn btn-primary btn-lg") }}
+            </div>
+          </form>
+        </div>
+      </div>
     </div>
   </div>
-</div><!-- /.container -->
+</div>
 {% endblock %}

--- a/newspipe/templates/errors/404.html
+++ b/newspipe/templates/errors/404.html
@@ -3,10 +3,18 @@
 {{ super() }}
 {% endblock %}
 {% block content %}
-<div class="container">
-    <div class="well">
-        <h1>Page Not Found</h1>
-        <p>What you were looking for is just not there, go to the <a href="{{ url_for('home') }}">home page</a>.</p>
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-sm rounded-3 text-center">
+        <div class="card-body p-5">
+          <i class="bi bi-compass display-4 text-muted d-block mb-3"></i>
+          <h1 class="h3 mb-3">{{ _('Page Not Found') }}</h1>
+          <p class="text-muted mb-4">{{ _('What you were looking for is just not there.') }}</p>
+          <a class="btn btn-primary" href="{{ url_for('home') }}">{{ _('Go to the home page') }}</a>
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock %}

--- a/newspipe/templates/errors/500.html
+++ b/newspipe/templates/errors/500.html
@@ -3,10 +3,18 @@
 {{ super() }}
 {% endblock %}
 {% block content %}
-<div class="container">
-    <div class="well">
-        <h1>Internal Server Error</h1>
-        <p>Something bad just happened! Go to the <a href="{{ url_for('home') }}">home page</a>.</p>
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow-sm rounded-3 text-center">
+        <div class="card-body p-5">
+          <i class="bi bi-exclamation-triangle display-4 text-muted d-block mb-3"></i>
+          <h1 class="h3 mb-3">{{ _('Internal Server Error') }}</h1>
+          <p class="text-muted mb-4">{{ _('Something bad just happened!') }}</p>
+          <a class="btn btn-primary" href="{{ url_for('home') }}">{{ _('Go to the home page') }}</a>
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 {% endblock %}

--- a/newspipe/templates/feed_list_per_categories.html
+++ b/newspipe/templates/feed_list_per_categories.html
@@ -1,23 +1,21 @@
-<div class="row">
-  <div class="col-md-6">
-    <form>
+<form class="mb-4">
+  <div class="row">
+    <div class="col-md-6">
       <div class="input-group">
-        <select class="form-control" id="category-select" name="category_id">
-          <option  value="0">All</option>
+        <select class="form-select" id="category-select" name="category_id">
+          <option value="0">{{ _('All') }}</option>
           {% for category in user.categories %}
             <option value="{{category.id}}" {% if category.id==selected_category_id %}selected{% endif %}>{{ category.name }}</option>
           {% endfor %}
         </select>
-        <button type="submit" class="btn btn-primary">Filter</button>
+        <button type="submit" class="btn btn-primary">{{ _('Filter') }}</button>
       </div>
-    </form>
+    </div>
   </div>
-</div>
-
-<br />
+</form>
 
 <div class="table-responsive">
-  <table id="table-feeds" class="table table-striped">
+  <table id="table-feeds" class="table table-striped table-hover align-middle">
     <thead>
       <tr>
         <th>#</th>

--- a/newspipe/templates/profile_public.html
+++ b/newspipe/templates/profile_public.html
@@ -1,38 +1,32 @@
 {% extends "layout.html" %}
 {% block content %}
-<div class="container">
-  <h1>{{ user.nickname }} / <a href="{{ url_for('user.user_stream', nickname=user.nickname) }}">stream</a></h1>
-  <div class="row">
+<div class="container my-4">
+  <h1 class="h3 mb-4">{{ user.nickname }} / <a href="{{ url_for('user.user_stream', nickname=user.nickname) }}">stream</a></h1>
+
+  <div class="row g-4">
     <div class="col-md-6">
-      <p>
+      <p class="mb-1">
         <i class="bi bi-calendar-event"></i>&nbsp;{{ _('Member since') }}: {{ user.date_created | datetime }}
       </p>
       <p>
         <i class="bi bi-clock"></i>&nbsp;{{ _('Last seen') }}: {{ user.last_seen | datetime }}
       </p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-6">
       {% if user.bio %}
-        <h3>Bio</h3>
+        <h2 class="h5 mt-3">{{ _('Bio') }}</h2>
         <p>{{ user.bio }}</p>
       {% endif %}
     </div>
     <div class="col-md-6">
-        <ul class="list-group">
-          {% if user.webpage %}<li class="list-group-item"><i class="bi bi-globe" aria-hidden="true"></i> <a href="{{ user.webpage | safe }}" rel="noopener noreferrer me" target="_blank">{{ user.webpage | safe }}</a></li>{% endif %}
-          {% if user.mastodon %}<li class="list-group-item"><i class="bi bi-mastodon" aria-hidden="true"></i> <a href="{{ user.mastodon | safe }}" rel="noopener noreferrer me" target="_blank">{{ user.mastodon | safe }}</a></li>{% endif %}
-          {% if user.github %}<li class="list-group-item"><i class="bi bi-github" aria-hidden="true"></i> <a href="https://github.com/{{ user.github }}" rel="noopener noreferrer me" target="_blank">https://github.com/{{ user.github }}</a></li>{% endif %}
-          {% if user.linkedin %}<li class="list-group-item"><i class="bi bi-linkedin" aria-hidden="true"></i> <a href="https://www.linkedin.com/in/{{ user.linkedin | safe }}" rel="noopener noreferrer me" target="_blank">https://www.linkedin.com/in/{{ user.linkedin }}</a></li>{% endif %}
-        </ul>
+      <ul class="list-group">
+        {% if user.webpage %}<li class="list-group-item"><i class="bi bi-globe" aria-hidden="true"></i> <a href="{{ user.webpage | safe }}" rel="noopener noreferrer me" target="_blank">{{ user.webpage | safe }}</a></li>{% endif %}
+        {% if user.mastodon %}<li class="list-group-item"><i class="bi bi-mastodon" aria-hidden="true"></i> <a href="{{ user.mastodon | safe }}" rel="noopener noreferrer me" target="_blank">{{ user.mastodon | safe }}</a></li>{% endif %}
+        {% if user.github %}<li class="list-group-item"><i class="bi bi-github" aria-hidden="true"></i> <a href="https://github.com/{{ user.github }}" rel="noopener noreferrer me" target="_blank">https://github.com/{{ user.github }}</a></li>{% endif %}
+        {% if user.linkedin %}<li class="list-group-item"><i class="bi bi-linkedin" aria-hidden="true"></i> <a href="https://www.linkedin.com/in/{{ user.linkedin | safe }}" rel="noopener noreferrer me" target="_blank">https://www.linkedin.com/in/{{ user.linkedin }}</a></li>{% endif %}
+      </ul>
     </div>
   </div>
-    <h2>{{ _('Feeds') }}</h2>
-    <div class="row">
-        <div class="col-md-12">
-            {% include "feed_list_per_categories.html" %}
-        </div>
-    </div>
+
+  <h2 class="h4 mt-4 mb-3">{{ _('Feeds') }}</h2>
+  {% include "feed_list_per_categories.html" %}
 </div><!-- /.container -->
 {% endblock %}

--- a/newspipe/templates/user_stream.html
+++ b/newspipe/templates/user_stream.html
@@ -1,46 +1,33 @@
 {% extends "layout.html" %}
 {% block content %}
-<div class="container">
-    <div class="row">
-        <div class="col">
-            <form class="form-inline">
+<div class="container my-4">
+    <form class="mb-4">
+        <div class="row">
+            <div class="col-md-6">
                 <div class="input-group">
-                    <select class="form-control" id="category-select" name="category_id">
-                        <option  value="0">All</option>
+                    <select class="form-select" id="category-select" name="category_id">
+                        <option value="0">{{ _('All') }}</option>
                         {% for cur_category in user.categories %}
                             <option value="{{cur_category.id}}" {% if cur_category.id==category.id %}selected{% endif %}>{{ cur_category.name }}</option>
                         {% endfor %}
                     </select>
-                    <button type="submit" class="btn btn-primary">Filter</button>
+                    <button type="submit" class="btn btn-primary">{{ _('Filter') }}</button>
                 </div>
-            </form>
+            </div>
         </div>
-    </div>
-
-    <br /><br />
+    </form>
 
     {% if category %}
-    <div class="row">
-        <div class="col">
-            <p class="lead">Articles from the category <a href="{{ url_for('user.profile_public', nickname=user.nickname, category_id=category.id) }}">{{ category.name }}</a></p>
-        </div>
-    </div>
+        <p class="lead">{{ _('Articles from the category') }} <a href="{{ url_for('user.profile_public', nickname=user.nickname, category_id=category.id) }}">{{ category.name }}</a></p>
     {% endif %}
 
-    <div class="row">
-        <div class="col">
-            {{ pagination.info }}
-        </div>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        {{ pagination.info }}
     </div>
-
-    <div class="row">
-       <div class="col">
-           {{ pagination.links }}
-       </div>
-   </div>
+    {{ pagination.links }}
 
     <div class="table-responsive">
-        <table id="table-feeds" class="table table-striped">
+        <table id="table-feeds" class="table table-striped table-hover align-middle">
             <thead>
                 <tr>
                     <th>#</th>
@@ -62,10 +49,6 @@
         </table>
     </div>
 
-    <div class="row">
-       <div class="col">
-           {{ pagination.links }}
-       </div>
-   </div>
+    {{ pagination.links }}
 </div><!-- /.container -->
 {% endblock %}


### PR DESCRIPTION
## Summary

This branch hardens article rendering/sanitization and extends the recent UI refresh to the pages it hadn't yet reached.

### Article rendering & sanitization
- Allow structural and media tags through the sanitizer while stripping unknown tags.
- Constrain expanded article content width and keep media inside its bounds.
- Add a `resanitize_articles` command to re-clean already-stored article HTML.
- Relax CSP to allow inline media from any HTTPS origin.

### UI harmonization
- Bring the templates untouched by the earlier theme refresh in line with the established design language: centered card forms (matching login/signup), surface-card lists, consistent containers and headings.
- Drive list styling through `theme.css` tokens: `.list-group` now sits on the same soft surface card as the article list (white surface, hairline borders, accent-soft hover). Standalone lists get rounded corners + shadow; flush lists inside cards keep just the tokens. Fixes bookmarks/profile_public rows blending into the page background.
- Form pages (`edit_category`, `edit_bookmark`, `admin/create_user`): replace deprecated `.form-horizontal`/`.control-label` with `.form-label` + `.mb-3` groups, inline red errors with `.invalid-feedback`, raw checkboxes with `.form-check`; drop a stray `</style>`.
- Error pages (404/500): replace the removed Bootstrap `.well` with a centered card + icon + primary CTA, with strings wrapped in `_()`.
- `categories`, `user_stream`, `feed_list_per_categories`, `profile_public`: consistent containers/headings, responsive grid instead of inline float CSS, drop deprecated `.form-inline` and `<br>` spacing, `form-select`, and i18n the controls.

### CI
- Pin a non-vulnerable `pip` in the pip-audit pre-commit hook's isolated env (PYSEC-2026-196); idna/urllib3 resolve to fixed versions on cache rebuild.

## Notes
- A few new translatable strings were introduced (`Filter`, `All`, `Bio`, the error-page text, etc.). They fall back to English until `pybabel extract`/`update` is run.
- UI changes are template/CSS only — no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)