### PR TITLE
new: [2fa] Add support of two-factor authentication (TOTP)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
     rev: v3.16.0
     hooks:
       - id: reorder-python-imports
+        # Alembic migrations start with a module docstring directly followed
+        # by imports: reorder-python-imports strips the blank line between
+        # them while black (>=24) re-inserts it, so the two hooks never
+        # converge on these generated files.
+        exclude: ^migrations/
   - repo: https://github.com/psf/black
     rev: 26.3.1
     hooks:

--- a/instance/config.py
+++ b/instance/config.py
@@ -75,6 +75,12 @@ MAIL_DEFAULT_SENDER = "admin@admin.localhost"
 TOKEN_VALIDITY_PERIOD = 3600
 PLATFORM_URL = "https://www.newspipe.org"
 
+# Issuer name displayed in the two-factor authentication application of the
+# users (below the TOTP code). It is recommended to use the public address of
+# your instance: users having accounts on several Newspipe instances will
+# easily find the right entry.
+TOTP_ISSUER = "www.newspipe.org"
+
 # Misc
 BASE_DIR = os.path.abspath(os.path.dirname("."))
 LANGUAGES = {"en": "English", "fr": "French", "de": "German"}

--- a/instance/sqlite.py
+++ b/instance/sqlite.py
@@ -71,6 +71,12 @@ MAIL_DEFAULT_SENDER = "admin@admin.localhost"
 TOKEN_VALIDITY_PERIOD = 3600
 PLATFORM_URL = "https://www.newspipe.org"
 
+# Issuer name displayed in the two-factor authentication application of the
+# users (below the TOTP code). It is recommended to use the public address of
+# your instance: users having accounts on several Newspipe instances will
+# easily find the right entry.
+TOTP_ISSUER = "www.newspipe.org"
+
 # Misc
 BASE_DIR = os.path.abspath(os.path.dirname("."))
 LANGUAGES = {"en": "English", "fr": "French", "de": "German"}

--- a/migrations/versions/c9b1e4a7d203_add_two_factor_authentication_columns_.py
+++ b/migrations/versions/c9b1e4a7d203_add_two_factor_authentication_columns_.py
@@ -1,0 +1,35 @@
+"""add two-factor authentication columns to user table
+
+Revision ID: c9b1e4a7d203
+Revises: f4e8c2a91b30
+Create Date: 2026-07-05 10:20:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c9b1e4a7d203"
+down_revision = "f4e8c2a91b30"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("user", sa.Column("totp_secret", sa.String(), nullable=True))
+    op.add_column(
+        "user",
+        sa.Column(
+            "totp_enabled", sa.Boolean(), nullable=True, server_default=sa.false()
+        ),
+    )
+    op.add_column("user", sa.Column("last_totp", sa.Integer(), nullable=True))
+    op.add_column("user", sa.Column("recovery_codes", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("user", "recovery_codes")
+    op.drop_column("user", "last_totp")
+    op.drop_column("user", "totp_enabled")
+    op.drop_column("user", "totp_secret")

--- a/newspipe/lib/twofactor.py
+++ b/newspipe/lib/twofactor.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python
+# Newspipe - A web news aggregator.
+# Copyright (C) 2010-2026 Cédric Bonhomme - https://www.cedricbonhomme.org
+#
+# For more information: https://github.com/cedricbonhomme/newspipe
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import json
+import secrets
+import time
+
+import pyotp
+import qrcode.image.svg
+from werkzeug.security import check_password_hash
+from werkzeug.security import generate_password_hash
+
+from newspipe.bootstrap import application
+
+RECOVERY_CODES_COUNT = 10
+
+
+def generate_totp_secret() -> str:
+    return pyotp.random_base32()
+
+
+def provisioning_uri(user) -> str:
+    # The issuer is displayed in the user's authenticator application: use the
+    # public address of the instance so users with accounts on several
+    # Newspipe instances can tell them apart.
+    issuer = application.config.get("TOTP_ISSUER", "Newspipe")
+    return pyotp.totp.TOTP(user.totp_secret).provisioning_uri(
+        name=user.nickname, issuer_name=issuer
+    )
+
+
+def qrcode_svg(user) -> str:
+    """
+    Return the enrollment QR code as an inline SVG string.
+    """
+    img = qrcode.make(
+        provisioning_uri(user),
+        image_factory=qrcode.image.svg.SvgPathFillImage,
+        box_size=12,
+    )
+    return img.to_string(encoding="unicode")
+
+
+def verify_totp(user, code: str):
+    """
+    Verify a TOTP code against the current and the previous timestep.
+
+    Return the matched timestep so the caller can persist it (replay
+    protection: a timestep lower or equal to user.last_totp is rejected),
+    or None if the code is invalid.
+    """
+    if not user.totp_secret:
+        return None
+    code = code.strip().replace(" ", "")
+    totp = pyotp.TOTP(user.totp_secret)
+    timecode = int(time.time()) // totp.interval
+    for counter in (timecode, timecode - 1):
+        if user.last_totp is not None and counter <= user.last_totp:
+            continue
+        if pyotp.utils.strings_equal(code, totp.generate_otp(counter)):
+            return counter
+    return None
+
+
+def generate_recovery_codes():
+    """
+    Return a tuple (codes, hashes_json): the plaintext recovery codes to
+    display once to the user, and the JSON list of their hashes to store.
+    """
+    codes = [
+        "-".join(secrets.token_hex(2) for _ in range(3))
+        for _ in range(RECOVERY_CODES_COUNT)
+    ]
+    hashes = [generate_password_hash(code) for code in codes]
+    return codes, json.dumps(hashes)
+
+
+def consume_recovery_code(user, code: str):
+    """
+    Check a recovery code against the stored hashes. If it matches, return
+    the updated JSON list with the used code removed (a recovery code is
+    only valid once). Return None if the code is invalid.
+    """
+    if not user.recovery_codes:
+        return None
+    code = code.strip().lower().replace(" ", "")
+    hashes = json.loads(user.recovery_codes)
+    for candidate in hashes:
+        if check_password_hash(candidate, code):
+            hashes.remove(candidate)
+            return json.dumps(hashes)
+    return None
+
+
+def remaining_recovery_codes(user) -> int:
+    if not user.recovery_codes:
+        return 0
+    return len(json.loads(user.recovery_codes))

--- a/newspipe/models/user.py
+++ b/newspipe/models/user.py
@@ -49,6 +49,14 @@ class User(db.Model, UserMixin, RightMixin):
     pwdhash = db.Column(db.String())
     external_auth = db.Column(db.String(), default="", nullable=True)
 
+    # two-factor authentication (TOTP)
+    totp_secret = db.Column(db.String(), default=None, nullable=True)
+    totp_enabled = db.Column(db.Boolean(), default=False)
+    # timestep of the last accepted TOTP code, to prevent replay
+    last_totp = db.Column(db.Integer(), default=None, nullable=True)
+    # JSON list of hashed one-time recovery codes
+    recovery_codes = db.Column(db.String(), default=None, nullable=True)
+
     automatic_crawling = db.Column(db.Boolean(), default=True)
 
     is_public_profile = db.Column(db.Boolean(), default=False)

--- a/newspipe/templates/login_2fa.html
+++ b/newspipe/templates/login_2fa.html
@@ -1,0 +1,37 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="container my-5">
+    <div class="row justify-content-center">
+        <div class="col-md-6 col-lg-4">
+            <div class="card shadow-sm rounded-3">
+                <div class="card-body p-4">
+                    <h3 class="text-center mb-4">
+                        <i class="bi bi-shield-lock me-2 text-primary"></i>{{ _('Two-factor authentication') }}
+                    </h3>
+                    <p class="text-muted">
+                        {{ _('Enter the code from your authenticator application.') }}
+                    </p>
+                    <form action="{{ url_for('login_2fa') }}" method="post" novalidate>
+                        {{ form.hidden_tag() }}
+
+                        <div class="mb-3">
+                            {{ form.code.label(class_="form-label") }}
+                            {{ form.code(class_="form-control", autofocus=True, autocomplete="one-time-code", placeholder="123456") }}
+                            {% for message in form.code.errors %}
+                                <div class="invalid-feedback d-block">{{ message }}</div>
+                            {% endfor %}
+                        </div>
+
+                        <div class="d-grid mb-3">
+                            {{ form.submit(class_="btn btn-primary btn-lg") }}
+                        </div>
+                    </form>
+                    <p class="text-muted small mb-0">
+                        {{ _('Lost your device? You can enter one of your recovery codes instead.') }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/newspipe/templates/profile.html
+++ b/newspipe/templates/profile.html
@@ -153,6 +153,26 @@
         </div>
     </div>
 
+    <!-- Security -->
+    <div class="card shadow-sm rounded-3 mb-4">
+        <div class="card-header">
+            <h2 class="h5 mb-0"><i class="bi bi-shield-lock me-2 text-primary"></i>{{ _('Security') }}</h2>
+        </div>
+        <div class="card-body p-4">
+            <p class="mb-3">
+                {{ _('Two-factor authentication') }}:
+                {% if user.totp_enabled %}
+                    <span class="badge text-bg-success">{{ _('enabled') }}</span>
+                {% else %}
+                    <span class="badge text-bg-secondary">{{ _('disabled') }}</span>
+                {% endif %}
+            </p>
+            <a href="{{ url_for('user.two_factor') }}" class="btn btn-outline-primary">
+                <i class="bi bi-shield-lock me-1"></i>{{ _('Manage two-factor authentication') }}
+            </a>
+        </div>
+    </div>
+
     <!-- Danger zone -->
     <div class="card shadow-sm rounded-3 border-danger">
         <div class="card-header bg-danger-subtle text-danger-emphasis">

--- a/newspipe/templates/two_factor.html
+++ b/newspipe/templates/two_factor.html
@@ -1,0 +1,136 @@
+{% extends "layout.html" %}
+{% block content %}
+<div class="container my-4">
+    <h1 class="h3 mb-4">
+        <i class="bi bi-shield-lock me-2 text-primary"></i>{{ _('Two-factor authentication') }}
+    </h1>
+
+    {% if new_codes %}
+    <!-- One-time display of the recovery codes -->
+    <div class="card shadow-sm rounded-3 mb-4 border-warning">
+        <div class="card-header bg-warning-subtle">
+            <h2 class="h5 mb-0"><i class="bi bi-life-preserver me-2"></i>{{ _('Your recovery codes') }}</h2>
+        </div>
+        <div class="card-body p-4">
+            <p>
+                {{ _('Store these recovery codes in a safe place. Each code can only be used once, and they are only displayed now.') }}
+            </p>
+            <ul class="list-unstyled row row-cols-2 row-cols-md-5 g-2 mb-0">
+                {% for code in new_codes %}
+                <li class="col"><code>{{ code }}</code></li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if user.totp_enabled %}
+    <!-- 2FA is enabled -->
+    <div class="card shadow-sm rounded-3 mb-4">
+        <div class="card-body p-4">
+            <p class="mb-0">
+                <i class="bi bi-check-circle-fill me-2 text-success"></i>
+                {{ _('Two-factor authentication is enabled on your account.') }}
+            </p>
+            <p class="mb-0 mt-2 text-muted">
+                {{ _('%(nb)d recovery code(s) remaining.', nb=nb_recovery_codes) }}
+            </p>
+        </div>
+    </div>
+
+    <div class="card shadow-sm rounded-3 mb-4">
+        <div class="card-header">
+            <h2 class="h5 mb-0"><i class="bi bi-arrow-repeat me-2 text-primary"></i>{{ _('Regenerate recovery codes') }}</h2>
+        </div>
+        <div class="card-body p-4">
+            <p class="text-muted">{{ _('Generate a new set of recovery codes. The current codes will no longer be valid.') }}</p>
+            <form action="{{ url_for('user.two_factor_recovery') }}" method="post" class="row g-2">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="col-auto">
+                    <input type="text" name="code" class="form-control" autocomplete="one-time-code"
+                           placeholder="{{ _('Authentication code') }}" required>
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-outline-primary">{{ _('Regenerate') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm rounded-3 border-danger">
+        <div class="card-header bg-danger-subtle text-danger-emphasis">
+            <h2 class="h5 mb-0"><i class="bi bi-exclamation-triangle-fill me-2"></i>{{ _('Disable two-factor authentication') }}</h2>
+        </div>
+        <div class="card-body p-4">
+            <p class="text-muted">{{ _('Enter a code from your authenticator application or one of your recovery codes.') }}</p>
+            <form action="{{ url_for('user.two_factor_disable') }}" method="post" class="row g-2">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="col-auto">
+                    <input type="text" name="code" class="form-control" autocomplete="one-time-code"
+                           placeholder="{{ _('Authentication code') }}" required>
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-danger">{{ _('Disable') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {% elif qrcode_svg %}
+    <!-- Enrollment pending: scan the QR code and confirm -->
+    <div class="card shadow-sm rounded-3 mb-4">
+        <div class="card-header">
+            <h2 class="h5 mb-0"><i class="bi bi-qr-code me-2 text-primary"></i>{{ _('Scan the QR code') }}</h2>
+        </div>
+        <div class="card-body p-4">
+            <p>{{ _('Scan this QR code with your authenticator application (FreeOTP, Aegis, etc.), then enter the generated code to confirm.') }}</p>
+            <div class="mb-3" style="max-width: 260px;">
+                {{ qrcode_svg | safe }}
+            </div>
+            <p class="text-muted small">
+                {{ _('If you cannot scan the QR code, enter this secret manually:') }}
+                <code>{{ user.totp_secret }}</code>
+            </p>
+            <form action="{{ url_for('user.two_factor_confirm') }}" method="post" class="row g-2">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="col-auto">
+                    <input type="text" name="code" class="form-control" autocomplete="one-time-code"
+                           inputmode="numeric" placeholder="123456" required>
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-primary">{{ _('Confirm') }}</button>
+                </div>
+            </form>
+            <form action="{{ url_for('user.two_factor_cancel') }}" method="post" class="mt-3">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-link text-muted p-0">{{ _('Cancel enrollment') }}</button>
+            </form>
+        </div>
+    </div>
+
+    {% else %}
+    <!-- 2FA is disabled -->
+    <div class="card shadow-sm rounded-3 mb-4">
+        <div class="card-body p-4">
+            <p>
+                <i class="bi bi-shield-slash me-2 text-muted"></i>
+                {{ _('Two-factor authentication is not enabled on your account.') }}
+            </p>
+            <p class="text-muted">
+                {{ _('With two-factor authentication, signing in requires a time-based code from an authenticator application in addition to your password.') }}
+            </p>
+            <form action="{{ url_for('user.two_factor_enable') }}" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-shield-lock me-1"></i>{{ _('Enable two-factor authentication') }}
+                </button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    <a href="{{ url_for('user.profile') }}" class="btn btn-link p-0">
+        <i class="bi bi-arrow-left me-1"></i>{{ _('Back to your profile') }}
+    </a>
+</div>
+{% endblock %}

--- a/newspipe/translations/de/LC_MESSAGES/messages.po
+++ b/newspipe/translations/de/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Newspipe\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-28 10:40+0200\n"
+"POT-Creation-Date: 2026-07-05 11:22+0200\n"
 "PO-Revision-Date: 2026-06-27 23:04+0200\n"
 "Last-Translator: Newspipe\n"
 "Language: de\n"
@@ -159,7 +159,7 @@ msgstr "Lesezeichen-Filter"
 msgid "All"
 msgstr "Alle"
 
-#: newspipe/templates/bookmarks.html:14 newspipe/web/forms.py:313
+#: newspipe/templates/bookmarks.html:14 newspipe/web/forms.py:325
 msgid "Private"
 msgstr "Privat"
 
@@ -448,8 +448,8 @@ msgstr "Status"
 #: newspipe/templates/feed_list.html:8
 #: newspipe/templates/feed_list_per_categories.html:22
 #: newspipe/templates/feed_list_simple.html:7
-#: newspipe/templates/user_stream.html:34 newspipe/web/forms.py:304
-#: newspipe/web/forms.py:341
+#: newspipe/templates/user_stream.html:34 newspipe/web/forms.py:316
+#: newspipe/web/forms.py:353
 msgid "Title"
 msgstr "Titel"
 
@@ -667,7 +667,7 @@ msgstr "Kategorien"
 msgid "Add a category"
 msgstr "Eine Kategorie hinzufügen"
 
-#: newspipe/templates/layout.html:94 newspipe/web/forms.py:322
+#: newspipe/templates/layout.html:94 newspipe/web/forms.py:334
 msgid "Category name"
 msgstr "Kategoriename"
 
@@ -735,6 +735,21 @@ msgstr "Ihr Passwort"
 #: newspipe/web/forms.py:82
 msgid "Sign up"
 msgstr "Registrieren"
+
+#: newspipe/templates/login_2fa.html:9 newspipe/templates/profile.html:163
+#: newspipe/templates/two_factor.html:5
+msgid "Two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung"
+
+#: newspipe/templates/login_2fa.html:12
+msgid "Enter the code from your authenticator application."
+msgstr "Geben Sie den Code aus Ihrer Authenticator-App ein."
+
+#: newspipe/templates/login_2fa.html:30
+msgid "Lost your device? You can enter one of your recovery codes instead."
+msgstr ""
+"Gerät verloren? Sie können stattdessen einen Ihrer "
+"Wiederherstellungscodes eingeben."
 
 #: newspipe/templates/macros.html:9
 msgid "simple match"
@@ -941,18 +956,34 @@ msgid "Uncheck if you are using your own crawler."
 msgstr "Deaktivieren Sie dies, wenn Sie Ihren eigenen Crawler verwenden."
 
 #: newspipe/templates/profile.html:159
+msgid "Security"
+msgstr "Sicherheit"
+
+#: newspipe/templates/profile.html:165
+msgid "enabled"
+msgstr "aktiviert"
+
+#: newspipe/templates/profile.html:167
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: newspipe/templates/profile.html:171
+msgid "Manage two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung verwalten"
+
+#: newspipe/templates/profile.html:179
 msgid "Danger zone"
 msgstr "Gefahrenzone"
 
-#: newspipe/templates/profile.html:162
+#: newspipe/templates/profile.html:182
 msgid "Once you delete your account, there is no going back."
 msgstr "Sobald Sie Ihr Konto löschen, gibt es kein Zurück mehr."
 
-#: newspipe/templates/profile.html:164
+#: newspipe/templates/profile.html:184
 msgid "You are going to delete your account."
 msgstr "Sie werden Ihr Konto löschen."
 
-#: newspipe/templates/profile.html:167
+#: newspipe/templates/profile.html:187
 msgid "Delete your account"
 msgstr "Ihr Konto löschen"
 
@@ -960,7 +991,7 @@ msgstr "Ihr Konto löschen"
 msgid "View stream"
 msgstr "Stream anzeigen"
 
-#: newspipe/templates/profile_public.html:28 newspipe/web/forms.py:261
+#: newspipe/templates/profile_public.html:28 newspipe/web/forms.py:273
 msgid "Bio"
 msgstr "Bio"
 
@@ -984,6 +1015,112 @@ msgstr "Mindestens 20 Zeichen."
 msgid "Already have an account? Log in"
 msgstr "Haben Sie bereits ein Konto? Anmelden"
 
+#: newspipe/templates/two_factor.html:12
+msgid "Your recovery codes"
+msgstr "Ihre Wiederherstellungscodes"
+
+#: newspipe/templates/two_factor.html:16
+msgid ""
+"Store these recovery codes in a safe place. Each code can only be used "
+"once, and they are only displayed now."
+msgstr ""
+"Bewahren Sie diese Wiederherstellungscodes an einem sicheren Ort auf. "
+"Jeder Code kann nur einmal verwendet werden, und sie werden nur jetzt "
+"angezeigt."
+
+#: newspipe/templates/two_factor.html:33
+msgid "Two-factor authentication is enabled on your account."
+msgstr "Die Zwei-Faktor-Authentifizierung ist für Ihr Konto aktiviert."
+
+#: newspipe/templates/two_factor.html:36
+#, python-format
+msgid "%(nb)d recovery code(s) remaining."
+msgstr "%(nb)d Wiederherstellungscode(s) übrig."
+
+#: newspipe/templates/two_factor.html:43
+msgid "Regenerate recovery codes"
+msgstr "Wiederherstellungscodes neu generieren"
+
+#: newspipe/templates/two_factor.html:46
+msgid ""
+"Generate a new set of recovery codes. The current codes will no longer be"
+" valid."
+msgstr ""
+"Einen neuen Satz Wiederherstellungscodes generieren. Die aktuellen Codes "
+"sind danach nicht mehr gültig."
+
+#: newspipe/templates/two_factor.html:51 newspipe/templates/two_factor.html:70
+msgid "Authentication code"
+msgstr "Authentifizierungscode"
+
+#: newspipe/templates/two_factor.html:54
+msgid "Regenerate"
+msgstr "Neu generieren"
+
+#: newspipe/templates/two_factor.html:62
+msgid "Disable two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung deaktivieren"
+
+#: newspipe/templates/two_factor.html:65
+msgid ""
+"Enter a code from your authenticator application or one of your recovery "
+"codes."
+msgstr ""
+"Geben Sie einen Code aus Ihrer Authenticator-App oder einen Ihrer "
+"Wiederherstellungscodes ein."
+
+#: newspipe/templates/two_factor.html:73
+msgid "Disable"
+msgstr "Deaktivieren"
+
+#: newspipe/templates/two_factor.html:83
+msgid "Scan the QR code"
+msgstr "QR-Code scannen"
+
+#: newspipe/templates/two_factor.html:86
+msgid ""
+"Scan this QR code with your authenticator application (FreeOTP, Aegis, "
+"etc.), then enter the generated code to confirm."
+msgstr ""
+"Scannen Sie diesen QR-Code mit Ihrer Authenticator-App (FreeOTP, Aegis "
+"usw.) und geben Sie anschließend den generierten Code zur Bestätigung "
+"ein."
+
+#: newspipe/templates/two_factor.html:91
+msgid "If you cannot scan the QR code, enter this secret manually:"
+msgstr ""
+"Wenn Sie den QR-Code nicht scannen können, geben Sie dieses Geheimnis "
+"manuell ein:"
+
+#: newspipe/templates/two_factor.html:101
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: newspipe/templates/two_factor.html:106
+msgid "Cancel enrollment"
+msgstr "Einrichtung abbrechen"
+
+#: newspipe/templates/two_factor.html:117
+msgid "Two-factor authentication is not enabled on your account."
+msgstr "Die Zwei-Faktor-Authentifizierung ist für Ihr Konto nicht aktiviert."
+
+#: newspipe/templates/two_factor.html:120
+msgid ""
+"With two-factor authentication, signing in requires a time-based code "
+"from an authenticator application in addition to your password."
+msgstr ""
+"Mit der Zwei-Faktor-Authentifizierung ist zur Anmeldung zusätzlich zu "
+"Ihrem Passwort ein zeitbasierter Code aus einer Authenticator-App "
+"erforderlich."
+
+#: newspipe/templates/two_factor.html:125
+msgid "Enable two-factor authentication"
+msgstr "Zwei-Faktor-Authentifizierung aktivieren"
+
+#: newspipe/templates/two_factor.html:133
+msgid "Back to your profile"
+msgstr "Zurück zu Ihrem Profil"
+
 #: newspipe/templates/user_stream.html:21
 msgid "Articles from the category"
 msgstr "Artikel aus der Kategorie"
@@ -1001,8 +1138,8 @@ msgid "Add a new user"
 msgstr "Einen neuen Benutzer hinzufügen"
 
 #: newspipe/templates/admin/dashboard.html:19 newspipe/web/forms.py:61
-#: newspipe/web/forms.py:127 newspipe/web/forms.py:228
-#: newspipe/web/forms.py:254
+#: newspipe/web/forms.py:139 newspipe/web/forms.py:240
+#: newspipe/web/forms.py:266
 msgid "Nickname"
 msgstr "Spitzname"
 
@@ -1054,7 +1191,7 @@ msgstr "Interner Serverfehler"
 msgid "Something bad just happened!"
 msgstr "Etwas Schlimmes ist gerade passiert!"
 
-#: newspipe/web/forms.py:62 newspipe/web/forms.py:130 newspipe/web/forms.py:229
+#: newspipe/web/forms.py:62 newspipe/web/forms.py:142 newspipe/web/forms.py:241
 msgid "Please enter your nickname."
 msgstr "Bitte geben Sie Ihren Spitznamen ein."
 
@@ -1070,12 +1207,12 @@ msgstr ""
 "Bitte geben Sie Ihre E-Mail-Adresse ein (nur zur Kontoaktivierung, wird "
 "nicht gespeichert)."
 
-#: newspipe/web/forms.py:76 newspipe/web/forms.py:134 newspipe/web/forms.py:231
-#: newspipe/web/forms.py:258 newspipe/web/forms.py:259
+#: newspipe/web/forms.py:76 newspipe/web/forms.py:146 newspipe/web/forms.py:243
+#: newspipe/web/forms.py:270 newspipe/web/forms.py:271
 msgid "Password"
 msgstr "Passwort"
 
-#: newspipe/web/forms.py:78 newspipe/web/forms.py:136
+#: newspipe/web/forms.py:78 newspipe/web/forms.py:148
 msgid "Please enter a password."
 msgstr "Bitte geben Sie ein Passwort ein."
 
@@ -1087,21 +1224,33 @@ msgstr ""
 "Dieser Spitzname enthält ungültige Zeichen. Bitte verwenden Sie nur "
 "Buchstaben, Zahlen, Bindestriche und Unterstriche."
 
-#: newspipe/web/forms.py:139
+#: newspipe/web/forms.py:107
+msgid "Code"
+msgstr "Code"
+
+#: newspipe/web/forms.py:108
+msgid "Please enter a code."
+msgstr "Bitte geben Sie einen Code ein."
+
+#: newspipe/web/forms.py:110
+msgid "Verify"
+msgstr "Überprüfen"
+
+#: newspipe/web/forms.py:151
 msgid "Log In"
 msgstr "Anmelden"
 
-#: newspipe/web/forms.py:232 newspipe/web/forms.py:260
+#: newspipe/web/forms.py:244 newspipe/web/forms.py:272
 msgid "Automatic crawling"
 msgstr "Automatisches Crawling"
 
-#: newspipe/web/forms.py:233 newspipe/web/forms.py:273
-#: newspipe/web/forms.py:309 newspipe/web/forms.py:329
-#: newspipe/web/forms.py:348
+#: newspipe/web/forms.py:245 newspipe/web/forms.py:285
+#: newspipe/web/forms.py:321 newspipe/web/forms.py:341
+#: newspipe/web/forms.py:360
 msgid "Save"
 msgstr "Speichern"
 
-#: newspipe/web/forms.py:240 newspipe/web/forms.py:294
+#: newspipe/web/forms.py:252 newspipe/web/forms.py:306
 msgid ""
 "This nickname has invalid characters. Please use letters, numbers, dots "
 "and underscores only."
@@ -1109,83 +1258,83 @@ msgstr ""
 "Dieser Spitzname enthält ungültige Zeichen. Bitte verwenden Sie nur "
 "Buchstaben, Zahlen, Punkte und Unterstriche."
 
-#: newspipe/web/forms.py:262
+#: newspipe/web/forms.py:274
 msgid "Webpage"
 msgstr "Webseite"
 
-#: newspipe/web/forms.py:272
+#: newspipe/web/forms.py:284
 msgid "Public profile"
 msgstr "Öffentliches Profil"
 
-#: newspipe/web/forms.py:279
+#: newspipe/web/forms.py:291
 msgid "Passwords aren't the same."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: newspipe/web/forms.py:285
+#: newspipe/web/forms.py:297
 msgid "Password must be between 20 and 500 characters."
 msgstr "Das Passwort muss zwischen 20 und 500 Zeichen lang sein."
 
-#: newspipe/web/forms.py:305
+#: newspipe/web/forms.py:317
 msgid "Feed link"
 msgstr "Feed-Link"
 
-#: newspipe/web/forms.py:306
+#: newspipe/web/forms.py:318
 msgid "Site link"
 msgstr "Website-Link"
 
-#: newspipe/web/forms.py:307 newspipe/web/forms.py:343
+#: newspipe/web/forms.py:319 newspipe/web/forms.py:355
 msgid "Description"
 msgstr "Beschreibung"
 
-#: newspipe/web/forms.py:308
+#: newspipe/web/forms.py:320
 msgid "Check for updates"
 msgstr "Auf Aktualisierungen prüfen"
 
-#: newspipe/web/forms.py:311
+#: newspipe/web/forms.py:323
 msgid "Category of the feed"
 msgstr "Kategorie des Feeds"
 
-#: newspipe/web/forms.py:328
+#: newspipe/web/forms.py:340
 msgid "Feeds in this category"
 msgstr "Feeds in dieser Kategorie"
 
-#: newspipe/web/forms.py:338
+#: newspipe/web/forms.py:350
 msgid "URL"
 msgstr "URL"
 
-#: newspipe/web/forms.py:339
+#: newspipe/web/forms.py:351
 msgid "Please enter an URL."
 msgstr "Bitte geben Sie eine URL ein."
 
-#: newspipe/web/forms.py:345
+#: newspipe/web/forms.py:357
 msgid "Tags"
 msgstr "Tags"
 
-#: newspipe/web/forms.py:346
+#: newspipe/web/forms.py:358
 msgid "To read"
 msgstr "Zu lesen"
 
-#: newspipe/web/forms.py:347
+#: newspipe/web/forms.py:359
 msgid "Shared"
 msgstr "Geteilt"
 
-#: newspipe/web/forms.py:353
+#: newspipe/web/forms.py:365
 msgid "Subject"
 msgstr "Betreff"
 
-#: newspipe/web/forms.py:354
+#: newspipe/web/forms.py:366
 msgid "Please enter a subject."
 msgstr "Bitte geben Sie einen Betreff ein."
 
-#: newspipe/web/forms.py:357
+#: newspipe/web/forms.py:369
 msgid "Message"
 msgstr "Nachricht"
 
-#: newspipe/web/forms.py:358
+#: newspipe/web/forms.py:370
 msgid "Please enter a content."
 msgstr "Bitte geben Sie einen Inhalt ein."
 
-#: newspipe/web/forms.py:360
+#: newspipe/web/forms.py:372
 msgid "Send"
 msgstr "Senden"
 
@@ -1198,7 +1347,7 @@ msgstr "Den Benutzer <i>%(nick)s</i> bearbeiten"
 msgid "Some errors were found"
 msgstr "Einige Fehler wurden gefunden"
 
-#: newspipe/web/views/admin.py:99 newspipe/web/views/user.py:231
+#: newspipe/web/views/admin.py:99 newspipe/web/views/user.py:232
 #, python-format
 msgid "User %(nick)s successfully updated"
 msgstr "Benutzer %(nick)s erfolgreich aktualisiert"
@@ -1227,7 +1376,7 @@ msgstr "Dieser Benutzer existiert nicht."
 msgid "User %(nickname)s successfully %(is_active)s"
 msgstr "Benutzer %(nickname)s erfolgreich %(is_active)s"
 
-#: newspipe/web/views/admin.py:176 newspipe/web/views/user.py:122
+#: newspipe/web/views/admin.py:176 newspipe/web/views/user.py:123
 msgid "Fetching articles…"
 msgstr "Artikel werden abgerufen…"
 
@@ -1379,64 +1528,96 @@ msgstr "Feed %(feed_title)r erfolgreich erstellt."
 msgid "No duplicates in the feed \"{}\"."
 msgstr "Keine Duplikate im Feed \"{}\"."
 
-#: newspipe/web/views/session_mgmt.py:114
+#: newspipe/web/views/session_mgmt.py:119
+msgid "Your login attempt has expired. Please sign in again."
+msgstr "Ihr Anmeldeversuch ist abgelaufen. Bitte melden Sie sich erneut an."
+
+#: newspipe/web/views/session_mgmt.py:143
+#, python-format
+msgid "You have %(nb)d recovery code(s) left."
+msgstr "Sie haben noch %(nb)d Wiederherstellungscode(s)."
+
+#: newspipe/web/views/session_mgmt.py:150 newspipe/web/views/user.py:301
+#: newspipe/web/views/user.py:342 newspipe/web/views/user.py:371
+msgid "Invalid code."
+msgstr "Ungültiger Code."
+
+#: newspipe/web/views/session_mgmt.py:185
 msgid "Self-registration is disabled."
 msgstr "Die Selbstregistrierung ist deaktiviert."
 
-#: newspipe/web/views/session_mgmt.py:132
+#: newspipe/web/views/session_mgmt.py:203
 #, python-format
 msgid "Problem while sending activation email: %(error)s"
 msgstr "Problem beim Senden der Aktivierungs-E-Mail: %(error)s"
 
-#: newspipe/web/views/session_mgmt.py:139
+#: newspipe/web/views/session_mgmt.py:210
 msgid "Your account has been created. Check your mail to confirm it."
 msgstr ""
 "Ihr Konto wurde erstellt. Überprüfen Sie Ihre E-Mails, um es zu "
 "bestätigen."
 
-#: newspipe/web/views/user.py:39 newspipe/web/views/user.py:64
+#: newspipe/web/views/user.py:40 newspipe/web/views/user.py:65
 msgid "You must set your profile to public."
 msgstr "Sie müssen Ihr Profil auf öffentlich stellen."
 
-#: newspipe/web/views/user.py:115 newspipe/web/views/user.py:129
-#: newspipe/web/views/user.py:137
+#: newspipe/web/views/user.py:116 newspipe/web/views/user.py:130
+#: newspipe/web/views/user.py:138
 msgid "File not allowed."
 msgstr "Datei nicht erlaubt."
 
-#: newspipe/web/views/user.py:121
+#: newspipe/web/views/user.py:122
 msgid "feeds imported."
 msgstr "Feeds importiert."
 
-#: newspipe/web/views/user.py:124
+#: newspipe/web/views/user.py:125
 msgid "Impossible to import the new feeds."
 msgstr "Die neuen Feeds konnten nicht importiert werden."
 
-#: newspipe/web/views/user.py:133
+#: newspipe/web/views/user.py:134
 msgid "Account imported."
 msgstr "Konto importiert."
 
-#: newspipe/web/views/user.py:135
+#: newspipe/web/views/user.py:136
 msgid "Impossible to import the account."
 msgstr "Das Konto konnte nicht importiert werden."
 
-#: newspipe/web/views/user.py:188
+#: newspipe/web/views/user.py:189
 msgid "Note deleted."
 msgstr "Notiz gelöscht."
 
-#: newspipe/web/views/user.py:225
+#: newspipe/web/views/user.py:226
 #, python-format
 msgid "Problem while updating your profile: %(error)s"
 msgstr "Problem beim Aktualisieren Ihres Profils: %(error)s"
 
-#: newspipe/web/views/user.py:252
+#: newspipe/web/views/user.py:278
+msgid "Two-factor authentication is already enabled."
+msgstr "Die Zwei-Faktor-Authentifizierung ist bereits aktiviert."
+
+#: newspipe/web/views/user.py:309
+msgid "Two-factor authentication is now enabled."
+msgstr "Die Zwei-Faktor-Authentifizierung ist jetzt aktiviert."
+
+#: newspipe/web/views/user.py:354
+msgid "Two-factor authentication has been disabled."
+msgstr "Die Zwei-Faktor-Authentifizierung wurde deaktiviert."
+
+#: newspipe/web/views/user.py:377
+msgid "New recovery codes generated. The old ones are no longer valid."
+msgstr ""
+"Neue Wiederherstellungscodes wurden generiert. Die alten sind nicht mehr "
+"gültig."
+
+#: newspipe/web/views/user.py:390
 msgid "Your account has been deleted."
 msgstr "Ihr Konto wurde gelöscht."
 
-#: newspipe/web/views/user.py:269
+#: newspipe/web/views/user.py:407
 msgid "Your account has been confirmed."
 msgstr "Ihr Konto wurde bestätigt."
 
-#: newspipe/web/views/user.py:271
+#: newspipe/web/views/user.py:409
 msgid "Impossible to confirm this account."
 msgstr "Dieses Konto konnte nicht bestätigt werden."
 

--- a/newspipe/translations/fr/LC_MESSAGES/messages.po
+++ b/newspipe/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Newspipe\n"
 "Report-Msgid-Bugs-To: cedric@cedricbonhomme.org\n"
-"POT-Creation-Date: 2026-06-28 10:40+0200\n"
+"POT-Creation-Date: 2026-07-05 11:22+0200\n"
 "PO-Revision-Date: 2025-09-13 18:08+0200\n"
 "Last-Translator: Cédric Bonhomme <cedric@cedricbonhomme.org>\n"
 "Language: fr\n"
@@ -159,7 +159,7 @@ msgstr "Filtres des marque-pages"
 msgid "All"
 msgstr "Tous"
 
-#: newspipe/templates/bookmarks.html:14 newspipe/web/forms.py:313
+#: newspipe/templates/bookmarks.html:14 newspipe/web/forms.py:325
 msgid "Private"
 msgstr "Privé"
 
@@ -446,8 +446,8 @@ msgstr "Statut"
 #: newspipe/templates/feed_list.html:8
 #: newspipe/templates/feed_list_per_categories.html:22
 #: newspipe/templates/feed_list_simple.html:7
-#: newspipe/templates/user_stream.html:34 newspipe/web/forms.py:304
-#: newspipe/web/forms.py:341
+#: newspipe/templates/user_stream.html:34 newspipe/web/forms.py:316
+#: newspipe/web/forms.py:353
 msgid "Title"
 msgstr "Titre"
 
@@ -665,7 +665,7 @@ msgstr "Catégories"
 msgid "Add a category"
 msgstr "Ajouter une catégorie"
 
-#: newspipe/templates/layout.html:94 newspipe/web/forms.py:322
+#: newspipe/templates/layout.html:94 newspipe/web/forms.py:334
 msgid "Category name"
 msgstr "Nom de la catégorie"
 
@@ -733,6 +733,21 @@ msgstr "Votre mot de passe"
 #: newspipe/web/forms.py:82
 msgid "Sign up"
 msgstr "S'inscrire"
+
+#: newspipe/templates/login_2fa.html:9 newspipe/templates/profile.html:163
+#: newspipe/templates/two_factor.html:5
+msgid "Two-factor authentication"
+msgstr "Authentification à deux facteurs"
+
+#: newspipe/templates/login_2fa.html:12
+msgid "Enter the code from your authenticator application."
+msgstr "Entrez le code fourni par votre application d'authentification."
+
+#: newspipe/templates/login_2fa.html:30
+msgid "Lost your device? You can enter one of your recovery codes instead."
+msgstr ""
+"Vous avez perdu votre appareil ? Vous pouvez entrer l'un de vos codes de "
+"récupération à la place."
 
 #: newspipe/templates/macros.html:9
 msgid "simple match"
@@ -941,20 +956,36 @@ msgid "Uncheck if you are using your own crawler."
 msgstr "Décochez si vous utilisez votre propre aspirateur de flux."
 
 #: newspipe/templates/profile.html:159
+msgid "Security"
+msgstr "Sécurité"
+
+#: newspipe/templates/profile.html:165
+msgid "enabled"
+msgstr "activée"
+
+#: newspipe/templates/profile.html:167
+msgid "disabled"
+msgstr "désactivée"
+
+#: newspipe/templates/profile.html:171
+msgid "Manage two-factor authentication"
+msgstr "Gérer l'authentification à deux facteurs"
+
+#: newspipe/templates/profile.html:179
 msgid "Danger zone"
 msgstr "Zone de danger"
 
-#: newspipe/templates/profile.html:162
+#: newspipe/templates/profile.html:182
 msgid "Once you delete your account, there is no going back."
 msgstr ""
 "Une fois votre compte supprimé, il n'y a pas de retour en arrière "
 "possible."
 
-#: newspipe/templates/profile.html:164
+#: newspipe/templates/profile.html:184
 msgid "You are going to delete your account."
 msgstr "Vous êtes sur le point de supprimer votre compte."
 
-#: newspipe/templates/profile.html:167
+#: newspipe/templates/profile.html:187
 msgid "Delete your account"
 msgstr "Supprimer votre compte"
 
@@ -962,7 +993,7 @@ msgstr "Supprimer votre compte"
 msgid "View stream"
 msgstr "Voir le flux"
 
-#: newspipe/templates/profile_public.html:28 newspipe/web/forms.py:261
+#: newspipe/templates/profile_public.html:28 newspipe/web/forms.py:273
 msgid "Bio"
 msgstr "Biographie"
 
@@ -986,6 +1017,108 @@ msgstr "Minimum 20 caractères."
 msgid "Already have an account? Log in"
 msgstr "Déjà un compte ? Connectez-vous"
 
+#: newspipe/templates/two_factor.html:12
+msgid "Your recovery codes"
+msgstr "Vos codes de récupération"
+
+#: newspipe/templates/two_factor.html:16
+msgid ""
+"Store these recovery codes in a safe place. Each code can only be used "
+"once, and they are only displayed now."
+msgstr ""
+"Conservez ces codes de récupération en lieu sûr. Chaque code ne peut être"
+" utilisé qu'une seule fois et ils ne sont affichés que maintenant."
+
+#: newspipe/templates/two_factor.html:33
+msgid "Two-factor authentication is enabled on your account."
+msgstr "L'authentification à deux facteurs est activée sur votre compte."
+
+#: newspipe/templates/two_factor.html:36
+#, python-format
+msgid "%(nb)d recovery code(s) remaining."
+msgstr "%(nb)d code(s) de récupération restant(s)."
+
+#: newspipe/templates/two_factor.html:43
+msgid "Regenerate recovery codes"
+msgstr "Régénérer les codes de récupération"
+
+#: newspipe/templates/two_factor.html:46
+msgid ""
+"Generate a new set of recovery codes. The current codes will no longer be"
+" valid."
+msgstr ""
+"Générer un nouveau jeu de codes de récupération. Les codes actuels ne "
+"seront plus valides."
+
+#: newspipe/templates/two_factor.html:51 newspipe/templates/two_factor.html:70
+msgid "Authentication code"
+msgstr "Code d'authentification"
+
+#: newspipe/templates/two_factor.html:54
+msgid "Regenerate"
+msgstr "Régénérer"
+
+#: newspipe/templates/two_factor.html:62
+msgid "Disable two-factor authentication"
+msgstr "Désactiver l'authentification à deux facteurs"
+
+#: newspipe/templates/two_factor.html:65
+msgid ""
+"Enter a code from your authenticator application or one of your recovery "
+"codes."
+msgstr ""
+"Entrez un code de votre application d'authentification ou l'un de vos "
+"codes de récupération."
+
+#: newspipe/templates/two_factor.html:73
+msgid "Disable"
+msgstr "Désactiver"
+
+#: newspipe/templates/two_factor.html:83
+msgid "Scan the QR code"
+msgstr "Scannez le code QR"
+
+#: newspipe/templates/two_factor.html:86
+msgid ""
+"Scan this QR code with your authenticator application (FreeOTP, Aegis, "
+"etc.), then enter the generated code to confirm."
+msgstr ""
+"Scannez ce code QR avec votre application d'authentification (FreeOTP, "
+"Aegis, etc.), puis entrez le code généré pour confirmer."
+
+#: newspipe/templates/two_factor.html:91
+msgid "If you cannot scan the QR code, enter this secret manually:"
+msgstr "Si vous ne pouvez pas scanner le code QR, entrez ce secret manuellement :"
+
+#: newspipe/templates/two_factor.html:101
+msgid "Confirm"
+msgstr "Confirmer"
+
+#: newspipe/templates/two_factor.html:106
+msgid "Cancel enrollment"
+msgstr "Annuler l'activation"
+
+#: newspipe/templates/two_factor.html:117
+msgid "Two-factor authentication is not enabled on your account."
+msgstr "L'authentification à deux facteurs n'est pas activée sur votre compte."
+
+#: newspipe/templates/two_factor.html:120
+msgid ""
+"With two-factor authentication, signing in requires a time-based code "
+"from an authenticator application in addition to your password."
+msgstr ""
+"Avec l'authentification à deux facteurs, la connexion nécessite, en plus "
+"de votre mot de passe, un code temporaire fourni par une application "
+"d'authentification."
+
+#: newspipe/templates/two_factor.html:125
+msgid "Enable two-factor authentication"
+msgstr "Activer l'authentification à deux facteurs"
+
+#: newspipe/templates/two_factor.html:133
+msgid "Back to your profile"
+msgstr "Retour à votre profil"
+
 #: newspipe/templates/user_stream.html:21
 msgid "Articles from the category"
 msgstr "Articles de la catégorie"
@@ -1003,8 +1136,8 @@ msgid "Add a new user"
 msgstr "Ajouter un nouvel utilisateur"
 
 #: newspipe/templates/admin/dashboard.html:19 newspipe/web/forms.py:61
-#: newspipe/web/forms.py:127 newspipe/web/forms.py:228
-#: newspipe/web/forms.py:254
+#: newspipe/web/forms.py:139 newspipe/web/forms.py:240
+#: newspipe/web/forms.py:266
 msgid "Nickname"
 msgstr "Pseudonyme"
 
@@ -1056,7 +1189,7 @@ msgstr "Erreur interne du serveur"
 msgid "Something bad just happened!"
 msgstr "Quelque chose s'est mal passé !"
 
-#: newspipe/web/forms.py:62 newspipe/web/forms.py:130 newspipe/web/forms.py:229
+#: newspipe/web/forms.py:62 newspipe/web/forms.py:142 newspipe/web/forms.py:241
 msgid "Please enter your nickname."
 msgstr "Veuillez entrer votre pseudonyme."
 
@@ -1072,12 +1205,12 @@ msgstr ""
 "Veuillez entrer votre adresse courriel (uniquement pour l'activation du "
 "compte, ne sera pas stockée)."
 
-#: newspipe/web/forms.py:76 newspipe/web/forms.py:134 newspipe/web/forms.py:231
-#: newspipe/web/forms.py:258 newspipe/web/forms.py:259
+#: newspipe/web/forms.py:76 newspipe/web/forms.py:146 newspipe/web/forms.py:243
+#: newspipe/web/forms.py:270 newspipe/web/forms.py:271
 msgid "Password"
 msgstr "Mot de passe"
 
-#: newspipe/web/forms.py:78 newspipe/web/forms.py:136
+#: newspipe/web/forms.py:78 newspipe/web/forms.py:148
 msgid "Please enter a password."
 msgstr "Veuillez entrer un mot de passe."
 
@@ -1089,21 +1222,33 @@ msgstr ""
 "Ce pseudonyme contient des caractères invalides. Veuillez utiliser "
 "uniquement des lettres, des chiffres, des tirets et des tirets bas."
 
-#: newspipe/web/forms.py:139
+#: newspipe/web/forms.py:107
+msgid "Code"
+msgstr "Code"
+
+#: newspipe/web/forms.py:108
+msgid "Please enter a code."
+msgstr "Veuillez entrer un code."
+
+#: newspipe/web/forms.py:110
+msgid "Verify"
+msgstr "Vérifier"
+
+#: newspipe/web/forms.py:151
 msgid "Log In"
 msgstr "Se connecter"
 
-#: newspipe/web/forms.py:232 newspipe/web/forms.py:260
+#: newspipe/web/forms.py:244 newspipe/web/forms.py:272
 msgid "Automatic crawling"
 msgstr "Récupération automatique"
 
-#: newspipe/web/forms.py:233 newspipe/web/forms.py:273
-#: newspipe/web/forms.py:309 newspipe/web/forms.py:329
-#: newspipe/web/forms.py:348
+#: newspipe/web/forms.py:245 newspipe/web/forms.py:285
+#: newspipe/web/forms.py:321 newspipe/web/forms.py:341
+#: newspipe/web/forms.py:360
 msgid "Save"
 msgstr "Enregistrer"
 
-#: newspipe/web/forms.py:240 newspipe/web/forms.py:294
+#: newspipe/web/forms.py:252 newspipe/web/forms.py:306
 msgid ""
 "This nickname has invalid characters. Please use letters, numbers, dots "
 "and underscores only."
@@ -1111,83 +1256,83 @@ msgstr ""
 "Ce pseudonyme contient des caractères invalides. Veuillez utiliser "
 "uniquement des lettres, des chiffres, des points et des tirets bas."
 
-#: newspipe/web/forms.py:262
+#: newspipe/web/forms.py:274
 msgid "Webpage"
 msgstr "Page web"
 
-#: newspipe/web/forms.py:272
+#: newspipe/web/forms.py:284
 msgid "Public profile"
 msgstr "Profil public"
 
-#: newspipe/web/forms.py:279
+#: newspipe/web/forms.py:291
 msgid "Passwords aren't the same."
 msgstr "Les mots de passe ne sont pas identiques."
 
-#: newspipe/web/forms.py:285
+#: newspipe/web/forms.py:297
 msgid "Password must be between 20 and 500 characters."
 msgstr "Le mot de passe doit contenir entre 20 et 500 caractères."
 
-#: newspipe/web/forms.py:305
+#: newspipe/web/forms.py:317
 msgid "Feed link"
 msgstr "Lien du flux"
 
-#: newspipe/web/forms.py:306
+#: newspipe/web/forms.py:318
 msgid "Site link"
 msgstr "Lien du site"
 
-#: newspipe/web/forms.py:307 newspipe/web/forms.py:343
+#: newspipe/web/forms.py:319 newspipe/web/forms.py:355
 msgid "Description"
 msgstr "Description"
 
-#: newspipe/web/forms.py:308
+#: newspipe/web/forms.py:320
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
 
-#: newspipe/web/forms.py:311
+#: newspipe/web/forms.py:323
 msgid "Category of the feed"
 msgstr "Catégorie du flux"
 
-#: newspipe/web/forms.py:328
+#: newspipe/web/forms.py:340
 msgid "Feeds in this category"
 msgstr "Flux dans cette catégorie"
 
-#: newspipe/web/forms.py:338
+#: newspipe/web/forms.py:350
 msgid "URL"
 msgstr "URL"
 
-#: newspipe/web/forms.py:339
+#: newspipe/web/forms.py:351
 msgid "Please enter an URL."
 msgstr "Veuillez entrer une URL."
 
-#: newspipe/web/forms.py:345
+#: newspipe/web/forms.py:357
 msgid "Tags"
 msgstr "Mots-clés"
 
-#: newspipe/web/forms.py:346
+#: newspipe/web/forms.py:358
 msgid "To read"
 msgstr "À lire"
 
-#: newspipe/web/forms.py:347
+#: newspipe/web/forms.py:359
 msgid "Shared"
 msgstr "Partagé"
 
-#: newspipe/web/forms.py:353
+#: newspipe/web/forms.py:365
 msgid "Subject"
 msgstr "Sujet"
 
-#: newspipe/web/forms.py:354
+#: newspipe/web/forms.py:366
 msgid "Please enter a subject."
 msgstr "Veuillez entrer un sujet."
 
-#: newspipe/web/forms.py:357
+#: newspipe/web/forms.py:369
 msgid "Message"
 msgstr "Message"
 
-#: newspipe/web/forms.py:358
+#: newspipe/web/forms.py:370
 msgid "Please enter a content."
 msgstr "Veuillez entrer un contenu."
 
-#: newspipe/web/forms.py:360
+#: newspipe/web/forms.py:372
 msgid "Send"
 msgstr "Envoyer"
 
@@ -1200,7 +1345,7 @@ msgstr "Modifier l'utilisateur <i>%(nick)s</i>"
 msgid "Some errors were found"
 msgstr "Des erreurs ont été trouvées"
 
-#: newspipe/web/views/admin.py:99 newspipe/web/views/user.py:231
+#: newspipe/web/views/admin.py:99 newspipe/web/views/user.py:232
 #, python-format
 msgid "User %(nick)s successfully updated"
 msgstr "L'utilisateur %(nick)s a été mis à jour avec succès"
@@ -1231,7 +1376,7 @@ msgstr "Cet utilisateur n'existe pas."
 msgid "User %(nickname)s successfully %(is_active)s"
 msgstr "L'utilisateur %(nickname)s a été %(is_active)s avec succès"
 
-#: newspipe/web/views/admin.py:176 newspipe/web/views/user.py:122
+#: newspipe/web/views/admin.py:176 newspipe/web/views/user.py:123
 msgid "Fetching articles…"
 msgstr "Récupération des articles…"
 
@@ -1381,62 +1526,92 @@ msgstr "Le flux %(feed_title)r a été créé avec succès."
 msgid "No duplicates in the feed \"{}\"."
 msgstr "Aucun doublon dans le flux « {} »."
 
-#: newspipe/web/views/session_mgmt.py:114
+#: newspipe/web/views/session_mgmt.py:119
+msgid "Your login attempt has expired. Please sign in again."
+msgstr "Votre tentative de connexion a expiré. Veuillez vous reconnecter."
+
+#: newspipe/web/views/session_mgmt.py:143
+#, python-format
+msgid "You have %(nb)d recovery code(s) left."
+msgstr "Il vous reste %(nb)d code(s) de récupération."
+
+#: newspipe/web/views/session_mgmt.py:150 newspipe/web/views/user.py:301
+#: newspipe/web/views/user.py:342 newspipe/web/views/user.py:371
+msgid "Invalid code."
+msgstr "Code invalide."
+
+#: newspipe/web/views/session_mgmt.py:185
 msgid "Self-registration is disabled."
 msgstr "L'auto-inscription est désactivée."
 
-#: newspipe/web/views/session_mgmt.py:132
+#: newspipe/web/views/session_mgmt.py:203
 #, python-format
 msgid "Problem while sending activation email: %(error)s"
 msgstr "Problème lors de l'envoi du courriel d'activation : %(error)s"
 
-#: newspipe/web/views/session_mgmt.py:139
+#: newspipe/web/views/session_mgmt.py:210
 msgid "Your account has been created. Check your mail to confirm it."
 msgstr "Votre compte a été créé. Vérifiez votre courriel pour le confirmer."
 
-#: newspipe/web/views/user.py:39 newspipe/web/views/user.py:64
+#: newspipe/web/views/user.py:40 newspipe/web/views/user.py:65
 msgid "You must set your profile to public."
 msgstr "Vous devez rendre votre profil public."
 
-#: newspipe/web/views/user.py:115 newspipe/web/views/user.py:129
-#: newspipe/web/views/user.py:137
+#: newspipe/web/views/user.py:116 newspipe/web/views/user.py:130
+#: newspipe/web/views/user.py:138
 msgid "File not allowed."
 msgstr "Fichier non autorisé."
 
-#: newspipe/web/views/user.py:121
+#: newspipe/web/views/user.py:122
 msgid "feeds imported."
 msgstr "flux importés."
 
-#: newspipe/web/views/user.py:124
+#: newspipe/web/views/user.py:125
 msgid "Impossible to import the new feeds."
 msgstr "Impossible d'importer les nouveaux flux."
 
-#: newspipe/web/views/user.py:133
+#: newspipe/web/views/user.py:134
 msgid "Account imported."
 msgstr "Compte importé."
 
-#: newspipe/web/views/user.py:135
+#: newspipe/web/views/user.py:136
 msgid "Impossible to import the account."
 msgstr "Impossible d'importer le compte."
 
-#: newspipe/web/views/user.py:188
+#: newspipe/web/views/user.py:189
 msgid "Note deleted."
 msgstr "Note supprimée."
 
-#: newspipe/web/views/user.py:225
+#: newspipe/web/views/user.py:226
 #, python-format
 msgid "Problem while updating your profile: %(error)s"
 msgstr "Problème lors de la mise à jour de votre profil : %(error)s"
 
-#: newspipe/web/views/user.py:252
+#: newspipe/web/views/user.py:278
+msgid "Two-factor authentication is already enabled."
+msgstr "L'authentification à deux facteurs est déjà activée."
+
+#: newspipe/web/views/user.py:309
+msgid "Two-factor authentication is now enabled."
+msgstr "L'authentification à deux facteurs est maintenant activée."
+
+#: newspipe/web/views/user.py:354
+msgid "Two-factor authentication has been disabled."
+msgstr "L'authentification à deux facteurs a été désactivée."
+
+#: newspipe/web/views/user.py:377
+msgid "New recovery codes generated. The old ones are no longer valid."
+msgstr "Nouveaux codes de récupération générés. Les anciens ne sont plus valides."
+
+#: newspipe/web/views/user.py:390
 msgid "Your account has been deleted."
 msgstr "Votre compte a été supprimé."
 
-#: newspipe/web/views/user.py:269
+#: newspipe/web/views/user.py:407
 msgid "Your account has been confirmed."
 msgstr "Votre compte a été confirmé."
 
-#: newspipe/web/views/user.py:271
+#: newspipe/web/views/user.py:409
 msgid "Impossible to confirm this account."
 msgstr "Impossible de confirmer ce compte."
 

--- a/newspipe/translations/messages.pot
+++ b/newspipe/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-28 10:40+0200\n"
+"POT-Creation-Date: 2026-07-05 11:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: newspipe/templates/bookmarks.html:14 newspipe/web/forms.py:313
+#: newspipe/templates/bookmarks.html:14 newspipe/web/forms.py:325
 msgid "Private"
 msgstr ""
 
@@ -424,8 +424,8 @@ msgstr ""
 #: newspipe/templates/feed_list.html:8
 #: newspipe/templates/feed_list_per_categories.html:22
 #: newspipe/templates/feed_list_simple.html:7
-#: newspipe/templates/user_stream.html:34 newspipe/web/forms.py:304
-#: newspipe/web/forms.py:341
+#: newspipe/templates/user_stream.html:34 newspipe/web/forms.py:316
+#: newspipe/web/forms.py:353
 msgid "Title"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "Add a category"
 msgstr ""
 
-#: newspipe/templates/layout.html:94 newspipe/web/forms.py:322
+#: newspipe/templates/layout.html:94 newspipe/web/forms.py:334
 msgid "Category name"
 msgstr ""
 
@@ -710,6 +710,19 @@ msgstr ""
 #: newspipe/templates/login.html:38 newspipe/templates/signup.html:8
 #: newspipe/web/forms.py:82
 msgid "Sign up"
+msgstr ""
+
+#: newspipe/templates/login_2fa.html:9 newspipe/templates/profile.html:163
+#: newspipe/templates/two_factor.html:5
+msgid "Two-factor authentication"
+msgstr ""
+
+#: newspipe/templates/login_2fa.html:12
+msgid "Enter the code from your authenticator application."
+msgstr ""
+
+#: newspipe/templates/login_2fa.html:30
+msgid "Lost your device? You can enter one of your recovery codes instead."
 msgstr ""
 
 #: newspipe/templates/macros.html:9
@@ -917,18 +930,34 @@ msgid "Uncheck if you are using your own crawler."
 msgstr ""
 
 #: newspipe/templates/profile.html:159
-msgid "Danger zone"
+msgid "Security"
 msgstr ""
 
-#: newspipe/templates/profile.html:162
-msgid "Once you delete your account, there is no going back."
-msgstr ""
-
-#: newspipe/templates/profile.html:164
-msgid "You are going to delete your account."
+#: newspipe/templates/profile.html:165
+msgid "enabled"
 msgstr ""
 
 #: newspipe/templates/profile.html:167
+msgid "disabled"
+msgstr ""
+
+#: newspipe/templates/profile.html:171
+msgid "Manage two-factor authentication"
+msgstr ""
+
+#: newspipe/templates/profile.html:179
+msgid "Danger zone"
+msgstr ""
+
+#: newspipe/templates/profile.html:182
+msgid "Once you delete your account, there is no going back."
+msgstr ""
+
+#: newspipe/templates/profile.html:184
+msgid "You are going to delete your account."
+msgstr ""
+
+#: newspipe/templates/profile.html:187
 msgid "Delete your account"
 msgstr ""
 
@@ -936,7 +965,7 @@ msgstr ""
 msgid "View stream"
 msgstr ""
 
-#: newspipe/templates/profile_public.html:28 newspipe/web/forms.py:261
+#: newspipe/templates/profile_public.html:28 newspipe/web/forms.py:273
 msgid "Bio"
 msgstr ""
 
@@ -960,6 +989,97 @@ msgstr ""
 msgid "Already have an account? Log in"
 msgstr ""
 
+#: newspipe/templates/two_factor.html:12
+msgid "Your recovery codes"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:16
+msgid ""
+"Store these recovery codes in a safe place. Each code can only be used "
+"once, and they are only displayed now."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:33
+msgid "Two-factor authentication is enabled on your account."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:36
+#, python-format
+msgid "%(nb)d recovery code(s) remaining."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:43
+msgid "Regenerate recovery codes"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:46
+msgid ""
+"Generate a new set of recovery codes. The current codes will no longer be"
+" valid."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:51 newspipe/templates/two_factor.html:70
+msgid "Authentication code"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:54
+msgid "Regenerate"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:62
+msgid "Disable two-factor authentication"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:65
+msgid ""
+"Enter a code from your authenticator application or one of your recovery "
+"codes."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:73
+msgid "Disable"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:83
+msgid "Scan the QR code"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:86
+msgid ""
+"Scan this QR code with your authenticator application (FreeOTP, Aegis, "
+"etc.), then enter the generated code to confirm."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:91
+msgid "If you cannot scan the QR code, enter this secret manually:"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:101
+msgid "Confirm"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:106
+msgid "Cancel enrollment"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:117
+msgid "Two-factor authentication is not enabled on your account."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:120
+msgid ""
+"With two-factor authentication, signing in requires a time-based code "
+"from an authenticator application in addition to your password."
+msgstr ""
+
+#: newspipe/templates/two_factor.html:125
+msgid "Enable two-factor authentication"
+msgstr ""
+
+#: newspipe/templates/two_factor.html:133
+msgid "Back to your profile"
+msgstr ""
+
 #: newspipe/templates/user_stream.html:21
 msgid "Articles from the category"
 msgstr ""
@@ -977,8 +1097,8 @@ msgid "Add a new user"
 msgstr ""
 
 #: newspipe/templates/admin/dashboard.html:19 newspipe/web/forms.py:61
-#: newspipe/web/forms.py:127 newspipe/web/forms.py:228
-#: newspipe/web/forms.py:254
+#: newspipe/web/forms.py:139 newspipe/web/forms.py:240
+#: newspipe/web/forms.py:266
 msgid "Nickname"
 msgstr ""
 
@@ -1030,7 +1150,7 @@ msgstr ""
 msgid "Something bad just happened!"
 msgstr ""
 
-#: newspipe/web/forms.py:62 newspipe/web/forms.py:130 newspipe/web/forms.py:229
+#: newspipe/web/forms.py:62 newspipe/web/forms.py:142 newspipe/web/forms.py:241
 msgid "Please enter your nickname."
 msgstr ""
 
@@ -1044,12 +1164,12 @@ msgid ""
 "stored)."
 msgstr ""
 
-#: newspipe/web/forms.py:76 newspipe/web/forms.py:134 newspipe/web/forms.py:231
-#: newspipe/web/forms.py:258 newspipe/web/forms.py:259
+#: newspipe/web/forms.py:76 newspipe/web/forms.py:146 newspipe/web/forms.py:243
+#: newspipe/web/forms.py:270 newspipe/web/forms.py:271
 msgid "Password"
 msgstr ""
 
-#: newspipe/web/forms.py:78 newspipe/web/forms.py:136
+#: newspipe/web/forms.py:78 newspipe/web/forms.py:148
 msgid "Please enter a password."
 msgstr ""
 
@@ -1059,103 +1179,115 @@ msgid ""
 "and underscores only."
 msgstr ""
 
-#: newspipe/web/forms.py:139
+#: newspipe/web/forms.py:107
+msgid "Code"
+msgstr ""
+
+#: newspipe/web/forms.py:108
+msgid "Please enter a code."
+msgstr ""
+
+#: newspipe/web/forms.py:110
+msgid "Verify"
+msgstr ""
+
+#: newspipe/web/forms.py:151
 msgid "Log In"
 msgstr ""
 
-#: newspipe/web/forms.py:232 newspipe/web/forms.py:260
+#: newspipe/web/forms.py:244 newspipe/web/forms.py:272
 msgid "Automatic crawling"
 msgstr ""
 
-#: newspipe/web/forms.py:233 newspipe/web/forms.py:273
-#: newspipe/web/forms.py:309 newspipe/web/forms.py:329
-#: newspipe/web/forms.py:348
+#: newspipe/web/forms.py:245 newspipe/web/forms.py:285
+#: newspipe/web/forms.py:321 newspipe/web/forms.py:341
+#: newspipe/web/forms.py:360
 msgid "Save"
 msgstr ""
 
-#: newspipe/web/forms.py:240 newspipe/web/forms.py:294
+#: newspipe/web/forms.py:252 newspipe/web/forms.py:306
 msgid ""
 "This nickname has invalid characters. Please use letters, numbers, dots "
 "and underscores only."
 msgstr ""
 
-#: newspipe/web/forms.py:262
+#: newspipe/web/forms.py:274
 msgid "Webpage"
 msgstr ""
 
-#: newspipe/web/forms.py:272
+#: newspipe/web/forms.py:284
 msgid "Public profile"
 msgstr ""
 
-#: newspipe/web/forms.py:279
+#: newspipe/web/forms.py:291
 msgid "Passwords aren't the same."
 msgstr ""
 
-#: newspipe/web/forms.py:285
+#: newspipe/web/forms.py:297
 msgid "Password must be between 20 and 500 characters."
 msgstr ""
 
-#: newspipe/web/forms.py:305
+#: newspipe/web/forms.py:317
 msgid "Feed link"
 msgstr ""
 
-#: newspipe/web/forms.py:306
+#: newspipe/web/forms.py:318
 msgid "Site link"
 msgstr ""
 
-#: newspipe/web/forms.py:307 newspipe/web/forms.py:343
+#: newspipe/web/forms.py:319 newspipe/web/forms.py:355
 msgid "Description"
 msgstr ""
 
-#: newspipe/web/forms.py:308
+#: newspipe/web/forms.py:320
 msgid "Check for updates"
 msgstr ""
 
-#: newspipe/web/forms.py:311
+#: newspipe/web/forms.py:323
 msgid "Category of the feed"
 msgstr ""
 
-#: newspipe/web/forms.py:328
+#: newspipe/web/forms.py:340
 msgid "Feeds in this category"
 msgstr ""
 
-#: newspipe/web/forms.py:338
+#: newspipe/web/forms.py:350
 msgid "URL"
 msgstr ""
 
-#: newspipe/web/forms.py:339
+#: newspipe/web/forms.py:351
 msgid "Please enter an URL."
 msgstr ""
 
-#: newspipe/web/forms.py:345
+#: newspipe/web/forms.py:357
 msgid "Tags"
 msgstr ""
 
-#: newspipe/web/forms.py:346
+#: newspipe/web/forms.py:358
 msgid "To read"
 msgstr ""
 
-#: newspipe/web/forms.py:347
+#: newspipe/web/forms.py:359
 msgid "Shared"
 msgstr ""
 
-#: newspipe/web/forms.py:353
+#: newspipe/web/forms.py:365
 msgid "Subject"
 msgstr ""
 
-#: newspipe/web/forms.py:354
+#: newspipe/web/forms.py:366
 msgid "Please enter a subject."
 msgstr ""
 
-#: newspipe/web/forms.py:357
+#: newspipe/web/forms.py:369
 msgid "Message"
 msgstr ""
 
-#: newspipe/web/forms.py:358
+#: newspipe/web/forms.py:370
 msgid "Please enter a content."
 msgstr ""
 
-#: newspipe/web/forms.py:360
+#: newspipe/web/forms.py:372
 msgid "Send"
 msgstr ""
 
@@ -1168,7 +1300,7 @@ msgstr ""
 msgid "Some errors were found"
 msgstr ""
 
-#: newspipe/web/views/admin.py:99 newspipe/web/views/user.py:231
+#: newspipe/web/views/admin.py:99 newspipe/web/views/user.py:232
 #, python-format
 msgid "User %(nick)s successfully updated"
 msgstr ""
@@ -1197,7 +1329,7 @@ msgstr ""
 msgid "User %(nickname)s successfully %(is_active)s"
 msgstr ""
 
-#: newspipe/web/views/admin.py:176 newspipe/web/views/user.py:122
+#: newspipe/web/views/admin.py:176 newspipe/web/views/user.py:123
 msgid "Fetching articles…"
 msgstr ""
 
@@ -1343,62 +1475,92 @@ msgstr ""
 msgid "No duplicates in the feed \"{}\"."
 msgstr ""
 
-#: newspipe/web/views/session_mgmt.py:114
+#: newspipe/web/views/session_mgmt.py:119
+msgid "Your login attempt has expired. Please sign in again."
+msgstr ""
+
+#: newspipe/web/views/session_mgmt.py:143
+#, python-format
+msgid "You have %(nb)d recovery code(s) left."
+msgstr ""
+
+#: newspipe/web/views/session_mgmt.py:150 newspipe/web/views/user.py:301
+#: newspipe/web/views/user.py:342 newspipe/web/views/user.py:371
+msgid "Invalid code."
+msgstr ""
+
+#: newspipe/web/views/session_mgmt.py:185
 msgid "Self-registration is disabled."
 msgstr ""
 
-#: newspipe/web/views/session_mgmt.py:132
+#: newspipe/web/views/session_mgmt.py:203
 #, python-format
 msgid "Problem while sending activation email: %(error)s"
 msgstr ""
 
-#: newspipe/web/views/session_mgmt.py:139
+#: newspipe/web/views/session_mgmt.py:210
 msgid "Your account has been created. Check your mail to confirm it."
 msgstr ""
 
-#: newspipe/web/views/user.py:39 newspipe/web/views/user.py:64
+#: newspipe/web/views/user.py:40 newspipe/web/views/user.py:65
 msgid "You must set your profile to public."
 msgstr ""
 
-#: newspipe/web/views/user.py:115 newspipe/web/views/user.py:129
-#: newspipe/web/views/user.py:137
+#: newspipe/web/views/user.py:116 newspipe/web/views/user.py:130
+#: newspipe/web/views/user.py:138
 msgid "File not allowed."
 msgstr ""
 
-#: newspipe/web/views/user.py:121
+#: newspipe/web/views/user.py:122
 msgid "feeds imported."
 msgstr ""
 
-#: newspipe/web/views/user.py:124
+#: newspipe/web/views/user.py:125
 msgid "Impossible to import the new feeds."
 msgstr ""
 
-#: newspipe/web/views/user.py:133
+#: newspipe/web/views/user.py:134
 msgid "Account imported."
 msgstr ""
 
-#: newspipe/web/views/user.py:135
+#: newspipe/web/views/user.py:136
 msgid "Impossible to import the account."
 msgstr ""
 
-#: newspipe/web/views/user.py:188
+#: newspipe/web/views/user.py:189
 msgid "Note deleted."
 msgstr ""
 
-#: newspipe/web/views/user.py:225
+#: newspipe/web/views/user.py:226
 #, python-format
 msgid "Problem while updating your profile: %(error)s"
 msgstr ""
 
-#: newspipe/web/views/user.py:252
+#: newspipe/web/views/user.py:278
+msgid "Two-factor authentication is already enabled."
+msgstr ""
+
+#: newspipe/web/views/user.py:309
+msgid "Two-factor authentication is now enabled."
+msgstr ""
+
+#: newspipe/web/views/user.py:354
+msgid "Two-factor authentication has been disabled."
+msgstr ""
+
+#: newspipe/web/views/user.py:377
+msgid "New recovery codes generated. The old ones are no longer valid."
+msgstr ""
+
+#: newspipe/web/views/user.py:390
 msgid "Your account has been deleted."
 msgstr ""
 
-#: newspipe/web/views/user.py:269
+#: newspipe/web/views/user.py:407
 msgid "Your account has been confirmed."
 msgstr ""
 
-#: newspipe/web/views/user.py:271
+#: newspipe/web/views/user.py:409
 msgid "Impossible to confirm this account."
 msgstr ""
 

--- a/newspipe/web/forms.py
+++ b/newspipe/web/forms.py
@@ -98,6 +98,18 @@ class SignupForm(FlaskForm):
         return validated
 
 
+class TwoFactorForm(FlaskForm):
+    """
+    Second authentication factor: a TOTP code or a recovery code.
+    """
+
+    code = StringField(
+        lazy_gettext("Code"),
+        [validators.DataRequired(lazy_gettext("Please enter a code."))],
+    )
+    submit = SubmitField(lazy_gettext("Verify"))
+
+
 class RedirectForm(FlaskForm):
     """
     Secure back redirects with WTForms.

--- a/newspipe/web/views/session_mgmt.py
+++ b/newspipe/web/views/session_mgmt.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime
 from datetime import timezone
@@ -25,9 +26,11 @@ from werkzeug.security import generate_password_hash
 
 from newspipe.bootstrap import application
 from newspipe.controllers import UserController
+from newspipe.lib import twofactor
 from newspipe.notifications import notifications
 from newspipe.web.forms import SigninForm
 from newspipe.web.forms import SignupForm
+from newspipe.web.forms import TwoFactorForm
 from newspipe.web.views.common import admin_role
 from newspipe.web.views.common import api_role
 from newspipe.web.views.common import login_user_bundle
@@ -75,7 +78,15 @@ def login():
 
     form = SigninForm()
 
-    if request.method == "POST" and form.validate():  # fixes an issue in flask-wtf
+    if (
+        request.method == "POST" and form.validate() and form.user is not None
+    ):  # fixes an issue in flask-wtf
+        if form.user.totp_enabled:
+            # password OK but a second factor is required: defer the login
+            session["twofactor_user_id"] = form.user.id
+            session["twofactor_since"] = datetime.now(timezone.utc).timestamp()
+            return redirect(url_for("login_2fa"))
+
         login_user_bundle(form.user)
 
         UserController(current_user.id).update(
@@ -89,6 +100,66 @@ def login():
         form=form,
         self_registration=application.config["SELF_REGISTRATION"],
     )
+
+
+TWOFACTOR_TIMEOUT = 300  # seconds granted to enter the second factor
+
+
+@current_app.route("/login/2fa", methods=["GET", "POST"])
+def login_2fa():
+    if current_user.is_authenticated:
+        return redirect(url_for("home"))
+
+    user_id = session.get("twofactor_user_id")
+    since = session.get("twofactor_since", 0)
+    elapsed = datetime.now(timezone.utc).timestamp() - since
+    if user_id is None or elapsed > TWOFACTOR_TIMEOUT:
+        session.pop("twofactor_user_id", None)
+        session.pop("twofactor_since", None)
+        flash(gettext("Your login attempt has expired. Please sign in again."), "info")
+        return redirect(url_for("login"))
+
+    ucontr = UserController(user_id, ignore_context=True)
+    try:
+        user = ucontr.get(id=user_id, is_active=True)
+    except NotFound:
+        session.pop("twofactor_user_id", None)
+        session.pop("twofactor_since", None)
+        return redirect(url_for("login"))
+
+    form = TwoFactorForm()
+    if request.method == "POST" and form.validate():
+        counter = twofactor.verify_totp(user, form.code.data)
+        if counter is not None:
+            # remember the accepted timestep so the same code cannot be replayed
+            ucontr.update({"id": user.id}, {"last_totp": counter})
+            return complete_2fa_login(user)
+
+        remaining_codes = twofactor.consume_recovery_code(user, form.code.data)
+        if remaining_codes is not None:
+            ucontr.update({"id": user.id}, {"recovery_codes": remaining_codes})
+            flash(
+                gettext(
+                    "You have %(nb)d recovery code(s) left.",
+                    nb=len(json.loads(remaining_codes)),
+                ),
+                "warning",
+            )
+            return complete_2fa_login(user)
+
+        flash(gettext("Invalid code."), "danger")
+
+    return render_template("login_2fa.html", form=form)
+
+
+def complete_2fa_login(user):
+    session.pop("twofactor_user_id", None)
+    session.pop("twofactor_since", None)
+    login_user_bundle(user)
+    UserController(user.id).update(
+        {"id": user.id}, {"last_seen": datetime.now(timezone.utc)}
+    )
+    return redirect(url_for("home"))
 
 
 @current_app.route("/logout")

--- a/newspipe/web/views/user.py
+++ b/newspipe/web/views/user.py
@@ -18,6 +18,7 @@ from newspipe.controllers import CategoryController
 from newspipe.controllers import FeedController
 from newspipe.controllers import UserController
 from newspipe.lib import misc_utils
+from newspipe.lib import twofactor
 from newspipe.lib.data import import_json
 from newspipe.lib.data import import_opml
 from newspipe.web.forms import ProfileForm
@@ -240,6 +241,143 @@ def profile():
         return render_template(
             "profile.html", user=user, form=form, nick_disabled=bool(user.external_auth)
         )
+
+
+def _render_two_factor(user, new_codes=None):
+    qrcode_svg = None
+    if user.totp_secret and not user.totp_enabled:
+        qrcode_svg = twofactor.qrcode_svg(user)
+    return render_template(
+        "two_factor.html",
+        user=user,
+        qrcode_svg=qrcode_svg,
+        new_codes=new_codes,
+        nb_recovery_codes=twofactor.remaining_recovery_codes(user),
+    )
+
+
+@user_bp.route("/two_factor", methods=["GET"])
+@login_required
+def two_factor():
+    """
+    Display the two-factor authentication management page.
+    """
+    user = UserController(current_user.id).get(id=current_user.id)
+    return _render_two_factor(user)
+
+
+@user_bp.route("/two_factor/enable", methods=["POST"])
+@login_required
+def two_factor_enable():
+    """
+    Start the enrollment: generate a secret, to be confirmed with a code.
+    """
+    user_contr = UserController(current_user.id)
+    user = user_contr.get(id=current_user.id)
+    if user.totp_enabled:
+        flash(gettext("Two-factor authentication is already enabled."), "warning")
+    else:
+        user_contr.update(
+            {"id": user.id},
+            {"totp_secret": twofactor.generate_totp_secret(), "totp_enabled": False},
+        )
+    return redirect(url_for("user.two_factor"))
+
+
+@user_bp.route("/two_factor/confirm", methods=["POST"])
+@login_required
+def two_factor_confirm():
+    """
+    Complete the enrollment by verifying a first TOTP code, then display
+    the recovery codes (only once).
+    """
+    user_contr = UserController(current_user.id)
+    user = user_contr.get(id=current_user.id)
+    if user.totp_enabled or not user.totp_secret:
+        return redirect(url_for("user.two_factor"))
+
+    counter = twofactor.verify_totp(user, request.form.get("code", ""))
+    if counter is None:
+        flash(gettext("Invalid code."), "danger")
+        return redirect(url_for("user.two_factor"))
+
+    codes, hashes = twofactor.generate_recovery_codes()
+    user_contr.update(
+        {"id": user.id},
+        {"totp_enabled": True, "last_totp": counter, "recovery_codes": hashes},
+    )
+    flash(gettext("Two-factor authentication is now enabled."), "success")
+    return _render_two_factor(user, new_codes=codes)
+
+
+@user_bp.route("/two_factor/cancel", methods=["POST"])
+@login_required
+def two_factor_cancel():
+    """
+    Abort a pending (unconfirmed) enrollment.
+    """
+    user_contr = UserController(current_user.id)
+    user = user_contr.get(id=current_user.id)
+    if not user.totp_enabled:
+        user_contr.update({"id": user.id}, {"totp_secret": None})
+    return redirect(url_for("user.two_factor"))
+
+
+@user_bp.route("/two_factor/disable", methods=["POST"])
+@login_required
+def two_factor_disable():
+    """
+    Disable two-factor authentication; requires a valid TOTP or recovery code.
+    """
+    user_contr = UserController(current_user.id)
+    user = user_contr.get(id=current_user.id)
+    if not user.totp_enabled:
+        return redirect(url_for("user.two_factor"))
+
+    code = request.form.get("code", "")
+    if (
+        twofactor.verify_totp(user, code) is None
+        and twofactor.consume_recovery_code(user, code) is None
+    ):
+        flash(gettext("Invalid code."), "danger")
+        return redirect(url_for("user.two_factor"))
+
+    user_contr.update(
+        {"id": user.id},
+        {
+            "totp_secret": None,
+            "totp_enabled": False,
+            "last_totp": None,
+            "recovery_codes": None,
+        },
+    )
+    flash(gettext("Two-factor authentication has been disabled."), "success")
+    return redirect(url_for("user.two_factor"))
+
+
+@user_bp.route("/two_factor/recovery", methods=["POST"])
+@login_required
+def two_factor_recovery():
+    """
+    Regenerate the recovery codes; requires a valid TOTP code.
+    """
+    user_contr = UserController(current_user.id)
+    user = user_contr.get(id=current_user.id)
+    if not user.totp_enabled:
+        return redirect(url_for("user.two_factor"))
+
+    counter = twofactor.verify_totp(user, request.form.get("code", ""))
+    if counter is None:
+        flash(gettext("Invalid code."), "danger")
+        return redirect(url_for("user.two_factor"))
+
+    codes, hashes = twofactor.generate_recovery_codes()
+    user_contr.update({"id": user.id}, {"last_totp": counter, "recovery_codes": hashes})
+    flash(
+        gettext("New recovery codes generated. The old ones are no longer valid."),
+        "success",
+    )
+    return _render_two_factor(user, new_codes=codes)
 
 
 @user_bp.route("/delete_account", methods=["POST"])

--- a/poetry.lock
+++ b/poetry.lock
@@ -650,11 +650,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
-markers = "platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cyclonedx-python-lib"
@@ -2575,6 +2575,21 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyotp"
+version = "2.10.0"
+description = "Python One Time Password Library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pyotp-2.10.0-py3-none-any.whl", hash = "sha256:1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c"},
+    {file = "pyotp-2.10.0.tar.gz", hash = "sha256:d01e9703443616b03c57c700b5cbffd56a1f929c1b0f8f03131bc78c1fca9d3f"},
+]
+
+[package.extras]
+test = ["coverage", "mypy", "ruff", "wheel"]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
@@ -2806,6 +2821,26 @@ files = [
     {file = "pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007"},
     {file = "pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"},
 ]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+description = "QR Code image generator"
+optional = false
+python-versions = "<4.0,>=3.9"
+groups = ["main"]
+files = [
+    {file = "qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f"},
+    {file = "qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+all = ["pillow (>=9.1.0)", "pypng"]
+pil = ["pillow (>=9.1.0)"]
+png = ["pypng"]
 
 [[package]]
 name = "requests"
@@ -3364,4 +3399,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "d5e60396bb8c0354ef97c65b0375206d3da79c0294a37351fd893f5cf69538d4"
+content-hash = "c7b57f56add9d80e55d4e31303ddab9b3c04c331cee8cb16fd783471d0e6addf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "ldap3 (>=2.9.1)",
     "pyvulnerabilitylookup (>=2.2.0)",
     "bleach (>=6.2.0,<7.0.0)",
+    "pyotp (>=2.10.0,<3.0.0)",
+    "qrcode (>=8.2,<9.0)",
 ]
 
 


### PR DESCRIPTION
Closes #72.

Users can enable two-factor authentication from their profile: a TOTP secret is enrolled by scanning a QR code (inline SVG) with an authenticator application and confirmed with a first code. Ten one-time recovery codes (stored hashed) are displayed once upon activation, and can regain access to the account if the device is lost.

When enabled, the login becomes two-step: after the password check, the user is asked for a TOTP code or a recovery code on /login/2fa (5-minute expiry). The timestep of the last accepted code is persisted so a code cannot be replayed. Disabling 2FA or regenerating the recovery codes also requires a valid code.

The issuer displayed in the authenticator application is configurable with TOTP_ISSUER; using the public address of the instance is recommended. French and German translations are included.

reorder-python-imports is now excluded on migrations/: it fights with black (>=24) over the blank line after the module docstring of the Alembic-generated files, so pre-commit could never converge on them.